### PR TITLE
feature/allow server without session storage or permissions

### DIFF
--- a/server/apollo.go
+++ b/server/apollo.go
@@ -30,17 +30,21 @@ type Apollo struct {
 // Populate populates the Apollo object with fields that need to be retrieved after initialisation.
 // E.g. fields that are stored in the active session.
 func (apollo *Apollo) populate() {
-	User, err := apollo.retrieveUser()
-	if err == core.ErrUnauthenticated {
-		apollo.User = nil
-	} else if err != nil {
-		slog.Error("Could not retrieve user object from session", "error", err)
-	} else {
-		apollo.User = User
+	if apollo.store != nil {
+		User, err := apollo.retrieveUser()
+		if err == core.ErrUnauthenticated {
+			apollo.User = nil
+		} else if err != nil {
+			slog.Error("Could not retrieve user object from session", "error", err)
+		} else {
+			apollo.User = User
+		}
 	}
-	err = permissions.RegisterApolloPermissions(apollo.permissions)
-	if err != nil {
-		slog.Error("Could not register Apollo permissions", "error", err)
+	if apollo.permissions != nil {
+		err := permissions.RegisterApolloPermissions(apollo.permissions)
+		if err != nil {
+			slog.Error("Could not register Apollo permissions", "error", err)
+		}
 	}
 }
 


### PR DESCRIPTION
When using an apollo server, we always need to configure session storage and a permissions service. In some cases (e.g. the upcoming SALT app), no permissions (or sessions?) are needed.