### PR TITLE
feature/add call to retrieve organisation children [sc-346]

### DIFF
--- a/postgres/internal/sqlc/organisations.sql.go
+++ b/postgres/internal/sqlc/organisations.sql.go
@@ -90,6 +90,35 @@ func (q *Queries) GetParentOrganisation(ctx context.Context, id int32) (*int32, 
 	return parent_id, err
 }
 
+const listOrganisationChildren = `-- name: ListOrganisationChildren :many
+SELECT
+	id, name, parent_id
+FROM
+	apollo.organisations
+WHERE
+	parent_id = $1
+`
+
+func (q *Queries) ListOrganisationChildren(ctx context.Context, parentID *int32) ([]ApolloOrganisation, error) {
+	rows, err := q.db.Query(ctx, listOrganisationChildren, parentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ApolloOrganisation
+	for rows.Next() {
+		var i ApolloOrganisation
+		if err := rows.Scan(&i.ID, &i.Name, &i.ParentID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listOrganisations = `-- name: ListOrganisations :many
 SELECT
     id, name, parent_id

--- a/postgres/organisation_service.go
+++ b/postgres/organisation_service.go
@@ -83,6 +83,16 @@ func (o *OrganisationService) ListOrganisations(ctx context.Context) ([]core.Org
 	return convertOrganisationList(organisations)
 }
 
+// ListOrganisationChildren implements core.OrganisationService.ListOrganisationChildren
+func (o *OrganisationService) ListOrganisationChildren(ctx context.Context, parentID core.OrganisationID) ([]core.Organisation, error) {
+	i32ParentID := int32(parentID)
+	organisations, err := o.q.ListOrganisationChildren(ctx, &i32ParentID)
+	if err != nil {
+		return nil, convertPgError(err)
+	}
+	return convertOrganisationList(organisations)
+}
+
 // ListUsersInOrganisation implements core.OrganisationService.ListUsersInOrganisation
 func (o *OrganisationService) ListUsersInOrganisation(ctx context.Context, id core.OrganisationID) ([]core.User, error) {
 	users, err := o.q.ListUsersInOrganisation(ctx, int32(id))

--- a/postgres/queries/organisations.sql
+++ b/postgres/queries/organisations.sql
@@ -29,6 +29,14 @@ RETURNING
 DELETE FROM apollo.organisations
 WHERE id = $1;
 
+-- name: ListOrganisationChildren :many
+SELECT
+	*
+FROM
+	apollo.organisations
+WHERE
+	parent_id = $1;
+
 -- name: ListOrganisationsForUser :many
 SELECT
     o.*


### PR DESCRIPTION
## This PR will:
- added new call to retrieve an organisation's children

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations (NA)
- [x] I ran `go mod tidy` after changing dependencies (NA)
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
