### PR TITLE
make ConvertPgError public so it can be used in wachtplanner

### DIFF
--- a/postgres/address_service.go
+++ b/postgres/address_service.go
@@ -45,7 +45,7 @@ func (a *AddressService) CreateAddressTx(
 		ExtraLine:  addressCreate.ExtraLine,
 	})
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertAddress(address)
 }
@@ -59,7 +59,7 @@ func (a *AddressService) DeleteAddress(ctx context.Context, id core.AddressID) e
 func (a *AddressService) GetAddress(ctx context.Context, id core.AddressID) (*core.Address, error) {
 	address, err := a.q.GetAddress(ctx, int32(id))
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertAddress(address)
 }
@@ -89,7 +89,7 @@ func (a *AddressService) UpdateAddress(
 func (a *AddressService) ListAddresses(ctx context.Context) ([]core.Address, error) {
 	addresses, err := a.q.ListAddresses(ctx)
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertAddressList(addresses)
 }

--- a/postgres/errors.go
+++ b/postgres/errors.go
@@ -9,10 +9,10 @@ import (
 	"github.com/prior-it/apollo/core"
 )
 
-// convertPgError will convert known postgres errors to their core variant.
+// ConvertPgError will convert known postgres errors to their core variant.
 // Unknown or unhandled errors will be returned as-is.
 // Converting nil will simply return nil.
-func convertPgError(err error) error {
+func ConvertPgError(err error) error {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
 		switch pgErr.Code {

--- a/postgres/organisation_service.go
+++ b/postgres/organisation_service.go
@@ -46,7 +46,7 @@ func (o *OrganisationService) AddOrganisation(
 	}
 	organisation, err := queries.CreateOrganisation(ctx, name, castParentID)
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertOrganisation(organisation)
 }
@@ -60,7 +60,7 @@ func (o *OrganisationService) DeleteOrganisation(ctx context.Context, id core.Or
 func (o *OrganisationService) GetAmountOfOrganisations(ctx context.Context) (uint64, error) {
 	amount, err := o.q.GetAmountOfOrganisations(ctx)
 	if err != nil {
-		return 0, convertPgError(err)
+		return 0, ConvertPgError(err)
 	}
 	return uint64(amount), nil
 }
@@ -69,7 +69,7 @@ func (o *OrganisationService) GetAmountOfOrganisations(ctx context.Context) (uin
 func (o *OrganisationService) GetOrganisation(ctx context.Context, id core.OrganisationID) (*core.Organisation, error) {
 	organisation, err := o.q.GetOrganisation(ctx, int32(id))
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertOrganisation(organisation)
 }
@@ -78,7 +78,7 @@ func (o *OrganisationService) GetOrganisation(ctx context.Context, id core.Organ
 func (o *OrganisationService) ListOrganisations(ctx context.Context) ([]core.Organisation, error) {
 	organisations, err := o.q.ListOrganisations(ctx)
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertOrganisationList(organisations)
 }
@@ -88,7 +88,7 @@ func (o *OrganisationService) ListOrganisationChildren(ctx context.Context, pare
 	i32ParentID := int32(parentID)
 	organisations, err := o.q.ListOrganisationChildren(ctx, &i32ParentID)
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertOrganisationList(organisations)
 }
@@ -97,7 +97,7 @@ func (o *OrganisationService) ListOrganisationChildren(ctx context.Context, pare
 func (o *OrganisationService) ListUsersInOrganisation(ctx context.Context, id core.OrganisationID) ([]core.User, error) {
 	users, err := o.q.ListUsersInOrganisation(ctx, int32(id))
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertUserList(users)
 }
@@ -106,7 +106,7 @@ func (o *OrganisationService) ListUsersInOrganisation(ctx context.Context, id co
 func (o *OrganisationService) ListOrganisationsForUser(ctx context.Context, id core.UserID) ([]core.Organisation, error) {
 	organisations, err := o.q.ListOrganisationsForUser(ctx, int32(id))
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertOrganisationList(organisations)
 }

--- a/postgres/permission_service.go
+++ b/postgres/permission_service.go
@@ -65,14 +65,14 @@ func (p *PermissionService) CreatePermissionGroup(
 			return nil, fmt.Errorf(
 				"could not create a new permission group with id %v: %w",
 				Group.ID,
-				convertPgError(err),
+				ConvertPgError(err),
 			)
 		}
 
 	} else {
 		NewGroup, err = q.CreatePermissionGroup(ctx, &Group.Name)
 		if err != nil {
-			return nil, fmt.Errorf("could not create the new permission group: %w", convertPgError(err))
+			return nil, fmt.Errorf("could not create the new permission group: %w", ConvertPgError(err))
 		}
 	}
 

--- a/postgres/user_service.go
+++ b/postgres/user_service.go
@@ -32,7 +32,7 @@ func (u *UserService) CreateUser(
 	}
 	user, err := u.q.CreateUser(ctx, name, email.String())
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertUser(user)
 }
@@ -46,7 +46,7 @@ func (u *UserService) DeleteUser(ctx context.Context, id core.UserID) error {
 func (u *UserService) GetAmountOfUsers(ctx context.Context) (uint64, error) {
 	amount, err := u.q.GetAmountOfUsers(ctx)
 	if err != nil {
-		return 0, convertPgError(err)
+		return 0, ConvertPgError(err)
 	}
 	return uint64(amount), nil
 }
@@ -55,7 +55,7 @@ func (u *UserService) GetAmountOfUsers(ctx context.Context) (uint64, error) {
 func (u *UserService) GetUser(ctx context.Context, id core.UserID) (*core.User, error) {
 	user, err := u.q.GetUser(ctx, int32(id))
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertUser(user)
 }
@@ -64,7 +64,7 @@ func (u *UserService) GetUser(ctx context.Context, id core.UserID) (*core.User, 
 func (u *UserService) ListUsers(ctx context.Context) ([]core.User, error) {
 	users, err := u.q.ListUsers(ctx)
 	if err != nil {
-		return nil, convertPgError(err)
+		return nil, ConvertPgError(err)
 	}
 	return convertUserList(users)
 }


### PR DESCRIPTION
## This PR will:
- allow the function convertPgError to be used in wachtplanner by making it public

## Checklist:
- [ ] I ran (and extended) the test suite
- [ ] I ran `just lint`
- [ ] I tested both up- and down-migrations
- [ ] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [ ] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
