### PR TITLE
Prevent migrations race condition

### DIFF
--- a/postgres/database.go
+++ b/postgres/database.go
@@ -77,6 +77,7 @@ func (db *ApolloDB) Migrate(folder embed.FS) error {
 		database,
 		fsys,
 		goose.WithSessionLocker(sessionLocker), // Use session-level advisory lock.
+		goose.WithVerbose(true),                // Enable logging (as with goose.Up)
 	)
 	if err != nil {
 		return fmt.Errorf("Cannot create goose provider: %w", err)


### PR DESCRIPTION
## This PR will:
- Prevent race conditions when running multiple migrations at the same time (like during testing)
- The first potential race condition is when creating the schemas. This is prevented by using a `pg_advisory_xact_lock` (transaction level advisory lock), which can only be used in a transaction.
- The second potential race condition is when creating tables in a migration. This is prevented by using a goose [`Provider`](https://pressly.github.io/goose/documentation/provider/#withsessionlocker), with a session lock (which is released after all migrations are finished). This session lock also uses a `pg_advisory_lock` (session level advisory lock) under the hood, which means that (for now), this is only supported for PostgreSQL databases.

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies (N/A)
- [x] I changed the PR title to be more descriptive
- [ ] I added the shortcut autolink in the PR title (e.g. `[sc-000]`) (N/A)
