### PR TITLE
Extend the apollo server

### DIFF
--- a/components/button_templ.go
+++ b/components/button_templ.go
@@ -119,14 +119,14 @@ func Button(props ButtonProps) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if len(props.HxGet) > 0 {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" hx-get=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" hx-disabled-elt=\"this\" hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(props.HxGet)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/button.templ`, Line: 66, Col: 23}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/button.templ`, Line: 67, Col: 23}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {

--- a/server/apollo.go
+++ b/server/apollo.go
@@ -35,10 +35,10 @@ func (apollo *Apollo) populate() {
 	if apollo.store != nil {
 		apollo.populateUser()
 		apollo.populateOrganisation()
-
 	} else {
 		slog.Warn("No session store provided, it will not be possible to log in")
 	}
+
 	if apollo.permissions != nil {
 		err := permissions.RegisterApolloPermissions(apollo.permissions)
 		if err != nil {

--- a/server/apollo.go
+++ b/server/apollo.go
@@ -350,12 +350,18 @@ func (apollo *Apollo) HasStrict(permission permissions.Permission) bool {
 // Redirect will return a response that redirects the user to the specified url.
 // If HTMX is available, this will redirect using HTMX.
 func (apollo *Apollo) Redirect(url string) {
+	apollo.RedirectWithCode(url, http.StatusSeeOther)
+}
+
+// Redirect will return a response that redirects the user to the specified url with the specified status code.
+// If HTMX is available, this will redirect using HTMX with status code 200 (so that HTMX would be triggered).
+func (apollo *Apollo) RedirectWithCode(url string, statusCode int) {
 	if apollo.GetHeader("HX-Request") == "true" {
 		apollo.AddHeader("HX-Redirect", url)
 		apollo.StatusCode(http.StatusOK)
 	} else {
 		apollo.AddHeader("Location", url)
-		apollo.StatusCode(http.StatusSeeOther)
+		apollo.StatusCode(statusCode)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -352,6 +352,25 @@ func (server *Server[state]) StaticFiles(pattern string, dir string, files fs.Re
 	}
 }
 
+// Group attaches another Handler or Router as a subrouter along a routing
+// path. It's very useful to split up a large API as many independent routers and
+// compose them as a single service. Or to attach an additional set of middleware
+// along a group of endpoints, e.g. a subtree of authenticated endpoints.
+//
+// Note that Group() does NOT return the original server but rather
+// a subroute server that only serves routes along the specified Group pattern.
+// This simply sets a wildcard along the `pattern` that will continue
+// routing at return subroute server. As a result, if you define two Group() routes on
+// the exact same pattern, the second group will panic.
+func (server *Server[state]) Group(
+	pattern string,
+) *Server[state] {
+	srv := Server[state](*server) //nolint:unconvert // shallow copy
+	srv.mux = chi.NewMux()
+	server.mux.Mount(pattern, srv.mux)
+	return &srv
+}
+
 // Get adds the route `pattern` that matches a GET http method to execute the `handlerFn` HandlerFunc.
 func (server *Server[state]) Get(
 	pattern string,

--- a/server/server.go
+++ b/server/server.go
@@ -158,7 +158,7 @@ func (server *Server[state]) handleMiddleware(
 
 func (server *Server[state]) AttachDefaultMiddleware() {
 	server.UseStd(
-		middleware.StripSlashes,
+		middleware.RedirectSlashes, // The FileServer warning should be irrelevant for our applications, but there might be edge cases where this does cause problems.
 		middleware.Recoverer,
 		middleware.RealIP,
 		middleware.RequestID,


### PR DESCRIPTION
## This PR will:
- Add a RedirectWithCode function to redirect with a custom status code
- Add Server.Group to group multiple endpoints that belong together

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
