### PR TITLE
Rename apolloDB to DB

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -22,7 +22,7 @@ import (
 // The state is responsible for closing the database in its own Close function after it's done using it.
 type BootstrappedState[state server.State] interface {
 	server.State
-	Init(server *server.Server[state], cfg *config.Config, db *postgres.ApolloDB)
+	Init(server *server.Server[state], cfg *config.Config, db *postgres.DB)
 }
 
 // Minimal creates a new server and initializes all default systems.

--- a/postgres/address_service.go
+++ b/postgres/address_service.go
@@ -8,14 +8,14 @@ import (
 	"github.com/prior-it/apollo/postgres/internal/sqlc"
 )
 
-func NewAddressService(DB *ApolloDB) *AddressService {
+func NewAddressService(DB *DB) *AddressService {
 	q := sqlc.New(DB)
 	return &AddressService{DB, q}
 }
 
 // Postgres implementation of the core AddressService interface.
 type AddressService struct {
-	db *ApolloDB
+	db *DB
 	q  *sqlc.Queries
 }
 

--- a/postgres/oauth_account_service.go
+++ b/postgres/oauth_account_service.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prior-it/apollo/postgres/internal/sqlc"
 )
 
-func NewOauthAccountService(db *ApolloDB) *PgOauthAccountService {
+func NewOauthAccountService(db *DB) *PgOauthAccountService {
 	q := sqlc.New(db)
 	return &PgOauthAccountService{q, db}
 }
@@ -22,7 +22,7 @@ func NewOauthAccountService(db *ApolloDB) *PgOauthAccountService {
 // Postgres implementation of the core UserService interface.
 type PgOauthAccountService struct {
 	q  *sqlc.Queries
-	db *ApolloDB
+	db *DB
 }
 
 // Force struct to implement the core interface

--- a/postgres/organisation_service.go
+++ b/postgres/organisation_service.go
@@ -8,14 +8,14 @@ import (
 	"github.com/prior-it/apollo/postgres/internal/sqlc"
 )
 
-func NewOrganisationService(DB *ApolloDB) *OrganisationService {
+func NewOrganisationService(DB *DB) *OrganisationService {
 	q := sqlc.New(DB)
 	return &OrganisationService{DB, q}
 }
 
 // Postgres implementation of the core OrganisationService interface.
 type OrganisationService struct {
-	db *ApolloDB
+	db *DB
 	q  *sqlc.Queries
 }
 
@@ -52,7 +52,10 @@ func (o *OrganisationService) AddOrganisation(
 }
 
 // DeleteOrganisation implements core.OrganisationService.DeleteOrganisation
-func (o *OrganisationService) DeleteOrganisation(ctx context.Context, id core.OrganisationID) error {
+func (o *OrganisationService) DeleteOrganisation(
+	ctx context.Context,
+	id core.OrganisationID,
+) error {
 	return o.q.DeleteOrganisation(ctx, int32(id))
 }
 
@@ -66,7 +69,10 @@ func (o *OrganisationService) GetAmountOfOrganisations(ctx context.Context) (uin
 }
 
 // GetOrganisation implements core.OrganisationService.GetOrganisation
-func (o *OrganisationService) GetOrganisation(ctx context.Context, id core.OrganisationID) (*core.Organisation, error) {
+func (o *OrganisationService) GetOrganisation(
+	ctx context.Context,
+	id core.OrganisationID,
+) (*core.Organisation, error) {
 	organisation, err := o.q.GetOrganisation(ctx, int32(id))
 	if err != nil {
 		return nil, ConvertPgError(err)
@@ -84,7 +90,10 @@ func (o *OrganisationService) ListOrganisations(ctx context.Context) ([]core.Org
 }
 
 // ListOrganisationChildren implements core.OrganisationService.ListOrganisationChildren
-func (o *OrganisationService) ListOrganisationChildren(ctx context.Context, parentID core.OrganisationID) ([]core.Organisation, error) {
+func (o *OrganisationService) ListOrganisationChildren(
+	ctx context.Context,
+	parentID core.OrganisationID,
+) ([]core.Organisation, error) {
 	i32ParentID := int32(parentID)
 	organisations, err := o.q.ListOrganisationChildren(ctx, &i32ParentID)
 	if err != nil {
@@ -94,7 +103,10 @@ func (o *OrganisationService) ListOrganisationChildren(ctx context.Context, pare
 }
 
 // ListUsersInOrganisation implements core.OrganisationService.ListUsersInOrganisation
-func (o *OrganisationService) ListUsersInOrganisation(ctx context.Context, id core.OrganisationID) ([]core.User, error) {
+func (o *OrganisationService) ListUsersInOrganisation(
+	ctx context.Context,
+	id core.OrganisationID,
+) ([]core.User, error) {
 	users, err := o.q.ListUsersInOrganisation(ctx, int32(id))
 	if err != nil {
 		return nil, ConvertPgError(err)
@@ -103,7 +115,10 @@ func (o *OrganisationService) ListUsersInOrganisation(ctx context.Context, id co
 }
 
 // ListOrganisationsForUser implements core.OrganisationService.ListOrganisationsForUser
-func (o *OrganisationService) ListOrganisationsForUser(ctx context.Context, id core.UserID) ([]core.Organisation, error) {
+func (o *OrganisationService) ListOrganisationsForUser(
+	ctx context.Context,
+	id core.UserID,
+) ([]core.Organisation, error) {
 	organisations, err := o.q.ListOrganisationsForUser(ctx, int32(id))
 	if err != nil {
 		return nil, ConvertPgError(err)
@@ -112,17 +127,30 @@ func (o *OrganisationService) ListOrganisationsForUser(ctx context.Context, id c
 }
 
 // AddUser implements core.OrganisationService.AddUser
-func (o *OrganisationService) AddUser(ctx context.Context, UserID core.UserID, OrgID core.OrganisationID) error {
+func (o *OrganisationService) AddUser(
+	ctx context.Context,
+	UserID core.UserID,
+	OrgID core.OrganisationID,
+) error {
 	return o.AddUserTx(ctx, o.db, UserID, OrgID)
 }
 
-func (o *OrganisationService) AddUserTx(ctx context.Context, dbtx sqlc.DBTX, UserID core.UserID, OrgID core.OrganisationID) error {
+func (o *OrganisationService) AddUserTx(
+	ctx context.Context,
+	dbtx sqlc.DBTX,
+	UserID core.UserID,
+	OrgID core.OrganisationID,
+) error {
 	queries := sqlc.New(dbtx)
 	return queries.AddUserToOrganisation(ctx, int32(UserID), int32(OrgID))
 }
 
 // RemoveUser implements core.OrganisationService.RemoveUser
-func (o *OrganisationService) RemoveUser(ctx context.Context, UserID core.UserID, OrgID core.OrganisationID) error {
+func (o *OrganisationService) RemoveUser(
+	ctx context.Context,
+	UserID core.UserID,
+	OrgID core.OrganisationID,
+) error {
 	return o.q.RemoveUserFromOrganisation(ctx, int32(UserID), int32(OrgID))
 }
 

--- a/postgres/permission_service.go
+++ b/postgres/permission_service.go
@@ -11,14 +11,14 @@ import (
 	"github.com/prior-it/apollo/postgres/internal/sqlc"
 )
 
-func NewPermissionService(DB *ApolloDB) *PermissionService {
+func NewPermissionService(DB *DB) *PermissionService {
 	sqlc := sqlc.New(DB)
 	return &PermissionService{db: DB, q: sqlc}
 }
 
 // Postgres implementation of the core UserService interface.
 type PermissionService struct {
-	db *ApolloDB
+	db *DB
 	q  *sqlc.Queries
 }
 

--- a/postgres/permission_service_test.go
+++ b/postgres/permission_service_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func CreateUserWithPermissions(
-	db *postgres.ApolloDB,
+	db *postgres.DB,
 	Permissions map[permissions.Permission]bool,
 ) *core.User {
 	ctx := context.Background()

--- a/postgres/user_service.go
+++ b/postgres/user_service.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prior-it/apollo/postgres/internal/sqlc"
 )
 
-func NewUserService(DB *ApolloDB) *UserService {
+func NewUserService(DB *DB) *UserService {
 	q := sqlc.New(DB)
 	return &UserService{q}
 }

--- a/tests/postgres.go
+++ b/tests/postgres.go
@@ -15,7 +15,7 @@ import (
 
 var Faker = gofakeit.New(rand.Uint64())
 
-func DB() *postgres.ApolloDB {
+func DB() *postgres.DB {
 	ctx := context.Background()
 	err := godotenv.Load("../.env")
 	if err != nil {


### PR DESCRIPTION
## This PR will:
- Rename apolloDB to simply "DB"

This prevents application code from having to repeat "apollo.apolloDB" or "postges.apolloDB". There aren't any other DB's in application code so it feels a bit redundant to have to specify this all the time

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
