### PR TITLE
Support unified Apollo <> App migrations

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -86,7 +86,7 @@ func Full[state BootstrappedState[state]](
 	}
 
 	// Connect to the database
-	db, err := postgres.NewDB(context.Background(), cfg.Database.URL)
+	db, err := postgres.NewDB(context.Background(), cfg.Database.URL, cfg.Database.Schema)
 	if err != nil {
 		logger.Error("Could not initialize database", "error", err)
 		os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -87,7 +87,7 @@ type SentryConfig struct {
 
 type DatabaseConfig struct {
 	URL    string
-	Schema string
+	Schema string `default:"public"`
 }
 
 type LogConfig struct {

--- a/postgres/address_service.go
+++ b/postgres/address_service.go
@@ -94,7 +94,7 @@ func (a *AddressService) ListAddresses(ctx context.Context) ([]core.Address, err
 	return convertAddressList(addresses)
 }
 
-func convertAddress(address sqlc.ApolloAddress) (*core.Address, error) {
+func convertAddress(address sqlc.Address) (*core.Address, error) {
 	id := core.AddressID(address.ID)
 	return &core.Address{
 		ID:         id,
@@ -107,7 +107,7 @@ func convertAddress(address sqlc.ApolloAddress) (*core.Address, error) {
 	}, nil
 }
 
-func convertAddressList(addresss []sqlc.ApolloAddress) ([]core.Address, error) {
+func convertAddressList(addresss []sqlc.Address) ([]core.Address, error) {
 	list := make([]core.Address, len(addresss))
 	for i, v := range addresss {
 		o, err := convertAddress(v)

--- a/postgres/address_service_test.go
+++ b/postgres/address_service_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAddressService(t *testing.T) {
-	db := tests.DB()
+	db := tests.DB(t)
 	service := postgres.NewAddressService(db)
 	ctx := context.Background()
 	defer tests.DeleteAllAddresses(service)
@@ -30,7 +30,12 @@ func TestAddressService(t *testing.T) {
 		address, err := service.CreateAddress(ctx, createData)
 		tests.Check(err)
 		assert.NotNil(t, address, "The first address should be created correctly")
-		assert.Equal(t, *address.ExtraLine, fakeAddress.State, "The extraLine field should be created correctly")
+		assert.Equal(
+			t,
+			*address.ExtraLine,
+			fakeAddress.State,
+			"The extraLine field should be created correctly",
+		)
 
 		createData.ExtraLine = nil
 		address, err = service.CreateAddress(ctx, createData)
@@ -69,7 +74,12 @@ func TestAddressService(t *testing.T) {
 			if typeOfAddress.Field(i).Name == "City" {
 				continue
 			}
-			assert.Equal(t, a.Field(i).Interface(), u.Field(i).Interface(), "Other fields should remain unchanged")
+			assert.Equal(
+				t,
+				a.Field(i).Interface(),
+				u.Field(i).Interface(),
+				"Other fields should remain unchanged",
+			)
 		}
 	})
 
@@ -91,6 +101,11 @@ func TestAddressService(t *testing.T) {
 		address, err = service.GetAddress(ctx, address.ID)
 		assert.NotNil(t, err, "Getting a deleted address should return an error")
 		assert.Nil(t, address, "Getting a deleted address should return nil for the address")
-		assert.ErrorIs(t, err, core.ErrNotFound, "Getting a deleted address should return ErrNotFound")
+		assert.ErrorIs(
+			t,
+			err,
+			core.ErrNotFound,
+			"Getting a deleted address should return ErrNotFound",
+		)
 	})
 }

--- a/postgres/database.go
+++ b/postgres/database.go
@@ -20,13 +20,16 @@ type DB struct {
 }
 
 // Initialise a new database connection. connString should be a valid postgres connection string (such as a postgres-url).
-func NewDB(ctx context.Context, connString string) (*DB, error) {
+// The database will use the specified schema, if it exists. If the schema doesn't exist yet, it will be created.
+func NewDB(ctx context.Context, connString, schema string) (*DB, error) {
 	slog.Info("Connecting to postgres database", "connString", connString)
 	pool, err := pgxpool.New(ctx, connString)
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to postgres database: %w", err)
 	}
-	return &DB{pool}, nil
+	db := &DB{pool}
+	err = db.SwitchSchema(ctx, schema)
+	return db, err
 }
 
 // Switch the database schema. If the specified schema does not exist already, this will create it.

--- a/postgres/internal/sqlc/account_cache.sql.go
+++ b/postgres/internal/sqlc/account_cache.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const createAccountCache = `-- name: CreateAccountCache :one
-INSERT INTO apollo.account_cache (name, email, provider, provider_id)
+INSERT INTO account_cache (name, email, provider, provider_id)
     VALUES ($1, $2, $3, $4)
 RETURNING
     id, name, email, provider, provider_id, created
@@ -25,14 +25,14 @@ type CreateAccountCacheParams struct {
 	ProviderID string
 }
 
-func (q *Queries) CreateAccountCache(ctx context.Context, arg CreateAccountCacheParams) (ApolloAccountCache, error) {
+func (q *Queries) CreateAccountCache(ctx context.Context, arg CreateAccountCacheParams) (AccountCache, error) {
 	row := q.db.QueryRow(ctx, createAccountCache,
 		arg.Name,
 		arg.Email,
 		arg.Provider,
 		arg.ProviderID,
 	)
-	var i ApolloAccountCache
+	var i AccountCache
 	err := row.Scan(
 		&i.ID,
 		&i.Name,
@@ -45,7 +45,7 @@ func (q *Queries) CreateAccountCache(ctx context.Context, arg CreateAccountCache
 }
 
 const deleteAccountCache = `-- name: DeleteAccountCache :exec
-DELETE FROM apollo.account_cache
+DELETE FROM account_cache
 WHERE id = $1
 `
 
@@ -55,7 +55,7 @@ func (q *Queries) DeleteAccountCache(ctx context.Context, id pgtype.UUID) error 
 }
 
 const deleteAccountCacheOldEntries = `-- name: DeleteAccountCacheOldEntries :exec
-DELETE FROM apollo.account_cache
+DELETE FROM account_cache
 WHERE created < NOW() - $1::interval
 `
 
@@ -68,15 +68,15 @@ const getAccountCacheForID = `-- name: GetAccountCacheForID :one
 SELECT
     id, name, email, provider, provider_id, created
 FROM
-    apollo.account_cache
+    account_cache
 WHERE
     id = $1
 LIMIT 1
 `
 
-func (q *Queries) GetAccountCacheForID(ctx context.Context, id pgtype.UUID) (ApolloAccountCache, error) {
+func (q *Queries) GetAccountCacheForID(ctx context.Context, id pgtype.UUID) (AccountCache, error) {
 	row := q.db.QueryRow(ctx, getAccountCacheForID, id)
-	var i ApolloAccountCache
+	var i AccountCache
 	err := row.Scan(
 		&i.ID,
 		&i.Name,

--- a/postgres/internal/sqlc/accounts.sql.go
+++ b/postgres/internal/sqlc/accounts.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const createAccount = `-- name: CreateAccount :one
-INSERT INTO apollo.accounts (user_id, provider, provider_id)
+INSERT INTO accounts (user_id, provider, provider_id)
     VALUES ($1, $2, $3)
 RETURNING
     user_id, provider, provider_id
@@ -22,15 +22,15 @@ type CreateAccountParams struct {
 	ProviderID string
 }
 
-func (q *Queries) CreateAccount(ctx context.Context, arg CreateAccountParams) (ApolloAccount, error) {
+func (q *Queries) CreateAccount(ctx context.Context, arg CreateAccountParams) (Account, error) {
 	row := q.db.QueryRow(ctx, createAccount, arg.UserID, arg.Provider, arg.ProviderID)
-	var i ApolloAccount
+	var i Account
 	err := row.Scan(&i.UserID, &i.Provider, &i.ProviderID)
 	return i, err
 }
 
 const deleteAccount = `-- name: DeleteAccount :exec
-DELETE FROM apollo.accounts
+DELETE FROM accounts
 WHERE provider = $1 AND provider_id = $2
 `
 
@@ -43,17 +43,17 @@ const getUserForProvider = `-- name: GetUserForProvider :one
 SELECT
     users.id, users.name, users.email, users.joined, users.admin
 FROM
-    apollo.users
-    INNER JOIN apollo.accounts ON users.id = accounts.user_id
+    users
+    INNER JOIN accounts ON users.id = accounts.user_id
 WHERE
     accounts.provider = $1
     AND accounts.provider_id = $2
 LIMIT 1
 `
 
-func (q *Queries) GetUserForProvider(ctx context.Context, provider string, providerID string) (ApolloUser, error) {
+func (q *Queries) GetUserForProvider(ctx context.Context, provider string, providerID string) (User, error) {
 	row := q.db.QueryRow(ctx, getUserForProvider, provider, providerID)
-	var i ApolloUser
+	var i User
 	err := row.Scan(
 		&i.ID,
 		&i.Name,

--- a/postgres/internal/sqlc/address.sql.go
+++ b/postgres/internal/sqlc/address.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const createAddress = `-- name: CreateAddress :one
-INSERT INTO apollo.address (street, number, extra_line, postal_code, city, country)
+INSERT INTO address (street, number, extra_line, postal_code, city, country)
 	VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING
 	id, street, number, postal_code, city, country, extra_line
@@ -25,7 +25,7 @@ type CreateAddressParams struct {
 	Country    string
 }
 
-func (q *Queries) CreateAddress(ctx context.Context, arg CreateAddressParams) (ApolloAddress, error) {
+func (q *Queries) CreateAddress(ctx context.Context, arg CreateAddressParams) (Address, error) {
 	row := q.db.QueryRow(ctx, createAddress,
 		arg.Street,
 		arg.Number,
@@ -34,7 +34,7 @@ func (q *Queries) CreateAddress(ctx context.Context, arg CreateAddressParams) (A
 		arg.City,
 		arg.Country,
 	)
-	var i ApolloAddress
+	var i Address
 	err := row.Scan(
 		&i.ID,
 		&i.Street,
@@ -48,7 +48,7 @@ func (q *Queries) CreateAddress(ctx context.Context, arg CreateAddressParams) (A
 }
 
 const deleteAddress = `-- name: DeleteAddress :exec
-DELETE FROM apollo.address
+DELETE FROM address
 WHERE id = $1
 `
 
@@ -61,15 +61,15 @@ const getAddress = `-- name: GetAddress :one
 SELECT
 	id, street, number, postal_code, city, country, extra_line
 FROM
-	apollo.address
+	address
 WHERE
 	id = $1
 LIMIT 1
 `
 
-func (q *Queries) GetAddress(ctx context.Context, id int32) (ApolloAddress, error) {
+func (q *Queries) GetAddress(ctx context.Context, id int32) (Address, error) {
 	row := q.db.QueryRow(ctx, getAddress, id)
-	var i ApolloAddress
+	var i Address
 	err := row.Scan(
 		&i.ID,
 		&i.Street,
@@ -86,18 +86,18 @@ const listAddresses = `-- name: ListAddresses :many
 SELECT
 	id, street, number, postal_code, city, country, extra_line
 FROM
-	apollo.address
+	address
 `
 
-func (q *Queries) ListAddresses(ctx context.Context) ([]ApolloAddress, error) {
+func (q *Queries) ListAddresses(ctx context.Context) ([]Address, error) {
 	rows, err := q.db.Query(ctx, listAddresses)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ApolloAddress
+	var items []Address
 	for rows.Next() {
-		var i ApolloAddress
+		var i Address
 		if err := rows.Scan(
 			&i.ID,
 			&i.Street,
@@ -119,7 +119,7 @@ func (q *Queries) ListAddresses(ctx context.Context) ([]ApolloAddress, error) {
 
 const updateAddress = `-- name: UpdateAddress :one
 UPDATE
-	apollo.address
+	address
 SET
 	street = COALESCE($2, street),
 	number = COALESCE($3, number),
@@ -143,7 +143,7 @@ type UpdateAddressParams struct {
 	Country    *string
 }
 
-func (q *Queries) UpdateAddress(ctx context.Context, arg UpdateAddressParams) (ApolloAddress, error) {
+func (q *Queries) UpdateAddress(ctx context.Context, arg UpdateAddressParams) (Address, error) {
 	row := q.db.QueryRow(ctx, updateAddress,
 		arg.ID,
 		arg.Street,
@@ -153,7 +153,7 @@ func (q *Queries) UpdateAddress(ctx context.Context, arg UpdateAddressParams) (A
 		arg.City,
 		arg.Country,
 	)
-	var i ApolloAddress
+	var i Address
 	err := row.Scan(
 		&i.ID,
 		&i.Street,

--- a/postgres/internal/sqlc/models.go
+++ b/postgres/internal/sqlc/models.go
@@ -8,13 +8,13 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-type ApolloAccount struct {
+type Account struct {
 	UserID     int32
 	Provider   string
 	ProviderID string
 }
 
-type ApolloAccountCache struct {
+type AccountCache struct {
 	ID         pgtype.UUID
 	Name       *string
 	Email      *string
@@ -23,7 +23,7 @@ type ApolloAccountCache struct {
 	Created    pgtype.Timestamptz
 }
 
-type ApolloAddress struct {
+type Address struct {
 	ID         int32
 	Street     string
 	Number     string
@@ -33,39 +33,39 @@ type ApolloAddress struct {
 	ExtraLine  *string
 }
 
-type ApolloOrganisation struct {
+type Organisation struct {
 	ID       int32
 	Name     string
 	ParentID *int32
 }
 
-type ApolloOrganisationUser struct {
+type OrganisationUser struct {
 	ID             int32
 	UserID         int32
 	OrganisationID int32
 }
 
-type ApolloOrganisationUsersPermissiongroup struct {
+type OrganisationUsersPermissiongroup struct {
 	OrganisationUsersID int32
 	PermissionGroupID   int32
 }
 
-type ApolloPermission struct {
+type Permission struct {
 	Name string
 }
 
-type ApolloPermissiongroup struct {
+type Permissiongroup struct {
 	ID   int32
 	Name *string
 }
 
-type ApolloPermissiongroupPermission struct {
+type PermissiongroupPermission struct {
 	GroupID    int32
 	Permission string
 	Enabled    bool
 }
 
-type ApolloUser struct {
+type User struct {
 	ID     int32
 	Name   string
 	Email  string
@@ -73,7 +73,7 @@ type ApolloUser struct {
 	Admin  bool
 }
 
-type ApolloUserPermissiongroupMembership struct {
+type UserPermissiongroupMembership struct {
 	GroupID int32
 	UserID  int32
 }

--- a/postgres/internal/sqlc/organisations.sql.go
+++ b/postgres/internal/sqlc/organisations.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const addUserToOrganisation = `-- name: AddUserToOrganisation :exec
-INSERT INTO apollo.organisation_users (user_id, organisation_id)
+INSERT INTO organisation_users (user_id, organisation_id)
     VALUES ($1, $2)
 `
 
@@ -20,21 +20,21 @@ func (q *Queries) AddUserToOrganisation(ctx context.Context, userID int32, organ
 }
 
 const createOrganisation = `-- name: CreateOrganisation :one
-INSERT INTO apollo.organisations (name, parent_id)
+INSERT INTO organisations (name, parent_id)
     VALUES ($1, $2)
 RETURNING
     id, name, parent_id
 `
 
-func (q *Queries) CreateOrganisation(ctx context.Context, name string, parentID *int32) (ApolloOrganisation, error) {
+func (q *Queries) CreateOrganisation(ctx context.Context, name string, parentID *int32) (Organisation, error) {
 	row := q.db.QueryRow(ctx, createOrganisation, name, parentID)
-	var i ApolloOrganisation
+	var i Organisation
 	err := row.Scan(&i.ID, &i.Name, &i.ParentID)
 	return i, err
 }
 
 const deleteOrganisation = `-- name: DeleteOrganisation :exec
-DELETE FROM apollo.organisations
+DELETE FROM organisations
 WHERE id = $1
 `
 
@@ -47,7 +47,7 @@ const getAmountOfOrganisations = `-- name: GetAmountOfOrganisations :one
 SELECT
     COUNT(id)
 FROM
-    apollo.organisations
+    organisations
 `
 
 func (q *Queries) GetAmountOfOrganisations(ctx context.Context) (int64, error) {
@@ -61,15 +61,15 @@ const getOrganisation = `-- name: GetOrganisation :one
 SELECT
     id, name, parent_id
 FROM
-    apollo.organisations
+    organisations
 WHERE
     id = $1
 LIMIT 1
 `
 
-func (q *Queries) GetOrganisation(ctx context.Context, id int32) (ApolloOrganisation, error) {
+func (q *Queries) GetOrganisation(ctx context.Context, id int32) (Organisation, error) {
 	row := q.db.QueryRow(ctx, getOrganisation, id)
-	var i ApolloOrganisation
+	var i Organisation
 	err := row.Scan(&i.ID, &i.Name, &i.ParentID)
 	return i, err
 }
@@ -78,7 +78,7 @@ const getParentOrganisation = `-- name: GetParentOrganisation :one
 SELECT
     parent_id
 FROM
-    apollo.organisations
+    organisations
 WHERE
     id = $1
 `
@@ -94,20 +94,20 @@ const listOrganisationChildren = `-- name: ListOrganisationChildren :many
 SELECT
 	id, name, parent_id
 FROM
-	apollo.organisations
+	organisations
 WHERE
 	parent_id = $1
 `
 
-func (q *Queries) ListOrganisationChildren(ctx context.Context, parentID *int32) ([]ApolloOrganisation, error) {
+func (q *Queries) ListOrganisationChildren(ctx context.Context, parentID *int32) ([]Organisation, error) {
 	rows, err := q.db.Query(ctx, listOrganisationChildren, parentID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ApolloOrganisation
+	var items []Organisation
 	for rows.Next() {
-		var i ApolloOrganisation
+		var i Organisation
 		if err := rows.Scan(&i.ID, &i.Name, &i.ParentID); err != nil {
 			return nil, err
 		}
@@ -123,18 +123,18 @@ const listOrganisations = `-- name: ListOrganisations :many
 SELECT
     id, name, parent_id
 FROM
-    apollo.organisations
+    organisations
 `
 
-func (q *Queries) ListOrganisations(ctx context.Context) ([]ApolloOrganisation, error) {
+func (q *Queries) ListOrganisations(ctx context.Context) ([]Organisation, error) {
 	rows, err := q.db.Query(ctx, listOrganisations)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ApolloOrganisation
+	var items []Organisation
 	for rows.Next() {
-		var i ApolloOrganisation
+		var i Organisation
 		if err := rows.Scan(&i.ID, &i.Name, &i.ParentID); err != nil {
 			return nil, err
 		}
@@ -150,21 +150,21 @@ const listOrganisationsForUser = `-- name: ListOrganisationsForUser :many
 SELECT
     o.id, o.name, o.parent_id
 FROM
-    apollo.organisations AS o
-    INNER JOIN apollo.organisation_users AS ou ON o.id = ou.organisation_id
+    organisations AS o
+    INNER JOIN organisation_users AS ou ON o.id = ou.organisation_id
 WHERE
     ou.user_id = $1
 `
 
-func (q *Queries) ListOrganisationsForUser(ctx context.Context, userID int32) ([]ApolloOrganisation, error) {
+func (q *Queries) ListOrganisationsForUser(ctx context.Context, userID int32) ([]Organisation, error) {
 	rows, err := q.db.Query(ctx, listOrganisationsForUser, userID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ApolloOrganisation
+	var items []Organisation
 	for rows.Next() {
-		var i ApolloOrganisation
+		var i Organisation
 		if err := rows.Scan(&i.ID, &i.Name, &i.ParentID); err != nil {
 			return nil, err
 		}
@@ -180,21 +180,21 @@ const listUsersInOrganisation = `-- name: ListUsersInOrganisation :many
 SELECT
     u.id, u.name, u.email, u.joined, u.admin
 FROM
-    apollo.users AS u
-    INNER JOIN apollo.organisation_users AS ou ON u.id = ou.user_id
+    users AS u
+    INNER JOIN organisation_users AS ou ON u.id = ou.user_id
 WHERE
     ou.organisation_id = $1
 `
 
-func (q *Queries) ListUsersInOrganisation(ctx context.Context, organisationID int32) ([]ApolloUser, error) {
+func (q *Queries) ListUsersInOrganisation(ctx context.Context, organisationID int32) ([]User, error) {
 	rows, err := q.db.Query(ctx, listUsersInOrganisation, organisationID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ApolloUser
+	var items []User
 	for rows.Next() {
-		var i ApolloUser
+		var i User
 		if err := rows.Scan(
 			&i.ID,
 			&i.Name,
@@ -213,7 +213,7 @@ func (q *Queries) ListUsersInOrganisation(ctx context.Context, organisationID in
 }
 
 const removeUserFromOrganisation = `-- name: RemoveUserFromOrganisation :exec
-DELETE FROM apollo.organisation_users
+DELETE FROM organisation_users
 WHERE user_id = $1
     AND organisation_id = $2
 `

--- a/postgres/internal/sqlc/users.sql.go
+++ b/postgres/internal/sqlc/users.sql.go
@@ -10,15 +10,15 @@ import (
 )
 
 const createUser = `-- name: CreateUser :one
-INSERT INTO apollo.users (name, email)
+INSERT INTO users (name, email)
     VALUES ($1, $2)
 RETURNING
     id, name, email, joined, admin
 `
 
-func (q *Queries) CreateUser(ctx context.Context, name string, email string) (ApolloUser, error) {
+func (q *Queries) CreateUser(ctx context.Context, name string, email string) (User, error) {
 	row := q.db.QueryRow(ctx, createUser, name, email)
-	var i ApolloUser
+	var i User
 	err := row.Scan(
 		&i.ID,
 		&i.Name,
@@ -30,7 +30,7 @@ func (q *Queries) CreateUser(ctx context.Context, name string, email string) (Ap
 }
 
 const deleteUser = `-- name: DeleteUser :exec
-DELETE FROM apollo.users
+DELETE FROM users
 WHERE id = $1
 `
 
@@ -43,7 +43,7 @@ const getAmountOfUsers = `-- name: GetAmountOfUsers :one
 SELECT
     COUNT(*)
 FROM
-    apollo.users
+    users
 `
 
 func (q *Queries) GetAmountOfUsers(ctx context.Context) (int64, error) {
@@ -57,15 +57,15 @@ const getUser = `-- name: GetUser :one
 SELECT
     id, name, email, joined, admin
 FROM
-    apollo.users
+    users
 WHERE
     id = $1
 LIMIT 1
 `
 
-func (q *Queries) GetUser(ctx context.Context, id int32) (ApolloUser, error) {
+func (q *Queries) GetUser(ctx context.Context, id int32) (User, error) {
 	row := q.db.QueryRow(ctx, getUser, id)
-	var i ApolloUser
+	var i User
 	err := row.Scan(
 		&i.ID,
 		&i.Name,
@@ -80,20 +80,20 @@ const listUsers = `-- name: ListUsers :many
 SELECT
     id, name, email, joined, admin
 FROM
-    apollo.users
+    users
 ORDER BY
     RANDOM()
 `
 
-func (q *Queries) ListUsers(ctx context.Context) ([]ApolloUser, error) {
+func (q *Queries) ListUsers(ctx context.Context) ([]User, error) {
 	rows, err := q.db.Query(ctx, listUsers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ApolloUser
+	var items []User
 	for rows.Next() {
-		var i ApolloUser
+		var i User
 		if err := rows.Scan(
 			&i.ID,
 			&i.Name,
@@ -113,7 +113,7 @@ func (q *Queries) ListUsers(ctx context.Context) ([]ApolloUser, error) {
 
 const updateUser = `-- name: UpdateUser :one
 UPDATE
-    apollo.users
+    users
 SET
     name = COALESCE($2, name),
     email = COALESCE($3, email)
@@ -129,9 +129,9 @@ type UpdateUserParams struct {
 	Email *string
 }
 
-func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (ApolloUser, error) {
+func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (User, error) {
 	row := q.db.QueryRow(ctx, updateUser, arg.ID, arg.Name, arg.Email)
-	var i ApolloUser
+	var i User
 	err := row.Scan(
 		&i.ID,
 		&i.Name,
@@ -144,7 +144,7 @@ func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (ApolloU
 
 const updateUserAdmin = `-- name: UpdateUserAdmin :exec
 UPDATE
-    apollo.users
+    users
 SET
     admin = $2
 WHERE

--- a/postgres/migrations/20240708145236_create_users.sql
+++ b/postgres/migrations/20240708145236_create_users.sql
@@ -1,8 +1,6 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE SCHEMA IF NOT EXISTS apollo;
-
-CREATE TABLE IF NOT EXISTS apollo.users (
+CREATE TABLE IF NOT EXISTS users (
     id serial NOT NULL,
     name text NOT NULL,
     email text NOT NULL,
@@ -11,25 +9,23 @@ CREATE TABLE IF NOT EXISTS apollo.users (
     UNIQUE (email)
 );
 
-CREATE TABLE IF NOT EXISTS apollo.accounts (
+CREATE TABLE IF NOT EXISTS accounts (
     user_id serial NOT NULL,
     provider text NOT NULL,
     provider_id text NOT NULL,
     PRIMARY KEY (user_id, provider),
-    FOREIGN KEY (user_id) REFERENCES apollo.users (id) ON DELETE CASCADE
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
-CREATE UNIQUE INDEX unique_provider_provider_id_idx ON apollo.accounts (provider, provider_id);
+CREATE UNIQUE INDEX unique_provider_provider_id_idx ON accounts (provider, provider_id);
 
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin
 DROP INDEX IF EXISTS unique_provider_provider_id_idx;
 
-DROP TABLE IF EXISTS apollo.accounts;
+DROP TABLE IF EXISTS accounts;
 
-DROP TABLE IF EXISTS apollo.users;
-
-DROP SCHEMA IF EXISTS apollo;
+DROP TABLE IF EXISTS users;
 
 -- +goose StatementEnd

--- a/postgres/migrations/20240813103028_account_cache.sql
+++ b/postgres/migrations/20240813103028_account_cache.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE apollo.account_cache (
-    id uuid NOT NULL DEFAULT gen_random_uuid(),
+CREATE TABLE account_cache (
+    id uuid NOT NULL DEFAULT gen_random_uuid (),
     name text,
     email text,
     provider text NOT NULL,
@@ -13,6 +13,6 @@ CREATE TABLE apollo.account_cache (
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin
-DROP TABLE IF EXISTS apollo.account_cache;
+DROP TABLE IF EXISTS account_cache;
 
 -- +goose StatementEnd

--- a/postgres/migrations/20240815133119_permissions.sql
+++ b/postgres/migrations/20240815133119_permissions.sql
@@ -1,48 +1,48 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE apollo.users
+ALTER TABLE users
     ADD COLUMN admin boolean NOT NULL DEFAULT FALSE;
 
-CREATE TABLE IF NOT EXISTS apollo.permissions (
+CREATE TABLE IF NOT EXISTS permissions (
     name text NOT NULL,
     PRIMARY KEY (name)
 );
 
-CREATE TABLE IF NOT EXISTS apollo.permissiongroups (
+CREATE TABLE IF NOT EXISTS permissiongroups (
     id serial NOT NULL,
     name text,
     PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS apollo.permissiongroup_permissions (
+CREATE TABLE IF NOT EXISTS permissiongroup_permissions (
     group_id serial NOT NULL,
     permission text NOT NULL,
     enabled boolean NOT NULL DEFAULT FALSE,
     PRIMARY KEY (group_id, permission),
-    FOREIGN KEY (permission) REFERENCES apollo.permissions (name) ON DELETE CASCADE,
-    FOREIGN KEY (group_id) REFERENCES apollo.permissiongroups (id) ON DELETE CASCADE
+    FOREIGN KEY (permission) REFERENCES permissions (name) ON DELETE CASCADE,
+    FOREIGN KEY (group_id) REFERENCES permissiongroups (id) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS apollo.user_permissiongroup_membership (
+CREATE TABLE IF NOT EXISTS user_permissiongroup_membership (
     group_id serial NOT NULL,
     user_id serial NOT NULL,
     PRIMARY KEY (group_id, user_id),
-    FOREIGN KEY (user_id) REFERENCES apollo.users (id) ON DELETE CASCADE,
-    FOREIGN KEY (group_id) REFERENCES apollo.permissiongroups (id) ON DELETE CASCADE
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    FOREIGN KEY (group_id) REFERENCES permissiongroups (id) ON DELETE CASCADE
 );
 
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin
-DROP TABLE IF EXISTS apollo.user_permissiongroup_membership;
+DROP TABLE IF EXISTS user_permissiongroup_membership;
 
-DROP TABLE IF EXISTS apollo.permissiongroup_permissions;
+DROP TABLE IF EXISTS permissiongroup_permissions;
 
-DROP TABLE IF EXISTS apollo.permissiongroups;
+DROP TABLE IF EXISTS permissiongroups;
 
-DROP TABLE IF EXISTS apollo.permissions;
+DROP TABLE IF EXISTS permissions;
 
-ALTER TABLE apollo.users
+ALTER TABLE users
     DROP COLUMN admin;
 
 -- +goose StatementEnd

--- a/postgres/migrations/20240816125548_create_organisations.sql
+++ b/postgres/migrations/20240816125548_create_organisations.sql
@@ -1,29 +1,29 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE IF NOT EXISTS apollo.organisations (
+CREATE TABLE IF NOT EXISTS organisations (
     id serial NOT NULL,
     name text NOT NULL,
     PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS apollo.organisation_users (
+CREATE TABLE IF NOT EXISTS organisation_users (
     id serial NOT NULL,
     user_id serial NOT NULL,
     organisation_id serial NOT NULL,
     PRIMARY KEY (id),
-    FOREIGN KEY (user_id) REFERENCES apollo.users (id) ON DELETE CASCADE,
-    FOREIGN KEY (organisation_id) REFERENCES apollo.organisations (id) ON DELETE CASCADE
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    FOREIGN KEY (organisation_id) REFERENCES organisations (id) ON DELETE CASCADE
 );
 
-CREATE UNIQUE INDEX unique_organisation_id_users_id_idx ON apollo.organisation_users (user_id, organisation_id);
+CREATE UNIQUE INDEX unique_organisation_id_users_id_idx ON organisation_users (user_id, organisation_id);
 
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin
 DROP INDEX IF EXISTS unique_organisation_id_users_id_idx;
 
-DROP TABLE IF EXISTS apollo.organisation_users;
+DROP TABLE IF EXISTS organisation_users;
 
-DROP TABLE IF EXISTS apollo.organisations;
+DROP TABLE IF EXISTS organisations;
 
 -- +goose StatementEnd

--- a/postgres/migrations/20240819125056_organisation_users_permissiongroups.sql
+++ b/postgres/migrations/20240819125056_organisation_users_permissiongroups.sql
@@ -1,16 +1,16 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE IF NOT EXISTS apollo.organisation_users_permissiongroups (
-	organisation_users_id serial NOT NULL,
-	permission_group_id serial NOT NULL,
-	PRIMARY KEY (organisation_users_id, permission_group_id),
-	FOREIGN KEY (permission_group_id) REFERENCES apollo.permissiongroups (id) ON DELETE CASCADE,
-	FOREIGN KEY (organisation_users_id) REFERENCES apollo.organisation_users (id) ON DELETE CASCADE
+CREATE TABLE IF NOT EXISTS organisation_users_permissiongroups (
+    organisation_users_id serial NOT NULL,
+    permission_group_id serial NOT NULL,
+    PRIMARY KEY (organisation_users_id, permission_group_id),
+    FOREIGN KEY (permission_group_id) REFERENCES permissiongroups (id) ON DELETE CASCADE,
+    FOREIGN KEY (organisation_users_id) REFERENCES organisation_users (id) ON DELETE CASCADE
 );
 
 -- +goose StatementEnd
-
 -- +goose Down
 -- +goose StatementBegin
-DROP TABLE IF EXISTS apollo.organisation_users_permissiongroups;
+DROP TABLE IF EXISTS organisation_users_permissiongroups;
+
 -- +goose StatementEnd

--- a/postgres/migrations/20240828081227_add_organisation_parent.sql
+++ b/postgres/migrations/20240828081227_add_organisation_parent.sql
@@ -1,13 +1,13 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE apollo.organisations
-ADD parent_id INTEGER NULL,
-ADD FOREIGN KEY (parent_id) REFERENCES apollo.organisations (id) ON DELETE CASCADE;
+ALTER TABLE organisations
+    ADD parent_id INTEGER NULL,
+    ADD FOREIGN KEY (parent_id) REFERENCES organisations (id) ON DELETE CASCADE;
 
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin
-ALTER TABLE apollo.organisations
-DROP COLUMN parent_id;
+ALTER TABLE organisations
+    DROP COLUMN parent_id;
 
 -- +goose StatementEnd

--- a/postgres/migrations/20240828150821_add_address.sql
+++ b/postgres/migrations/20240828150821_add_address.sql
@@ -1,17 +1,18 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE IF NOT EXISTS apollo.address (
-	id serial PRIMARY KEY,
-	street text NOT NULL,
-	number text NOT NULL,
-	postal_code text NOT NULL,
-	city text NOT NULL,
-	country text NOT NULL,
-	extra_line text
+CREATE TABLE IF NOT EXISTS address (
+    id serial PRIMARY KEY,
+    street text NOT NULL,
+    number text NOT NULL,
+    postal_code text NOT NULL,
+    city text NOT NULL,
+    country text NOT NULL,
+    extra_line text
 );
--- +goose StatementEnd
 
+-- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin
-DROP TABLE IF EXISTS apollo.address;
+DROP TABLE IF EXISTS address;
+
 -- +goose StatementEnd

--- a/postgres/organisation_service.go
+++ b/postgres/organisation_service.go
@@ -154,7 +154,7 @@ func (o *OrganisationService) RemoveUser(
 	return o.q.RemoveUserFromOrganisation(ctx, int32(UserID), int32(OrgID))
 }
 
-func convertOrganisation(organisation sqlc.ApolloOrganisation) (*core.Organisation, error) {
+func convertOrganisation(organisation sqlc.Organisation) (*core.Organisation, error) {
 	id := core.OrganisationID(organisation.ID)
 	var parentID *core.OrganisationID
 	if organisation.ParentID != nil {
@@ -168,7 +168,7 @@ func convertOrganisation(organisation sqlc.ApolloOrganisation) (*core.Organisati
 	}, nil
 }
 
-func convertOrganisationList(organisations []sqlc.ApolloOrganisation) ([]core.Organisation, error) {
+func convertOrganisationList(organisations []sqlc.Organisation) ([]core.Organisation, error) {
 	list := make([]core.Organisation, len(organisations))
 	for i, v := range organisations {
 		o, err := convertOrganisation(v)

--- a/postgres/organisation_service_test.go
+++ b/postgres/organisation_service_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestOrganisationService(t *testing.T) {
-	db := tests.DB()
+	db := tests.DB(t)
 	service := postgres.NewOrganisationService(db)
 	UserService := postgres.NewUserService(db)
 	defer tests.DeleteAllOrganisations(service)
@@ -37,7 +37,13 @@ func TestOrganisationService(t *testing.T) {
 			newOrg, err := service.CreateOrganisation(ctx, tests.Faker.BS(), &organisation1.ID)
 			tests.Check(err)
 			assert.NotNilf(t, newOrg, "Organisation with index %d should be created correctly", idx)
-			assert.Equalf(t, *newOrg.ParentID, organisation1.ID, "Organisation 1 should be the parent of organisation with index %d", idx)
+			assert.Equalf(
+				t,
+				*newOrg.ParentID,
+				organisation1.ID,
+				"Organisation 1 should be the parent of organisation with index %d",
+				idx,
+			)
 		}
 	})
 
@@ -61,8 +67,17 @@ func TestOrganisationService(t *testing.T) {
 
 		organisation2, err := service.GetOrganisation(ctx, organisation.ID)
 		assert.NotNil(t, err, "Getting a deleted organisation should return an error")
-		assert.Nil(t, organisation2, "Getting a deleted organisation should return nil for the organisation")
-		assert.ErrorIs(t, err, core.ErrNotFound, "Getting a deleted organisation should return ErrNotFound")
+		assert.Nil(
+			t,
+			organisation2,
+			"Getting a deleted organisation should return nil for the organisation",
+		)
+		assert.ErrorIs(
+			t,
+			err,
+			core.ErrNotFound,
+			"Getting a deleted organisation should return ErrNotFound",
+		)
 	})
 
 	t.Run("ok: delete organisation removes children", func(t *testing.T) {
@@ -74,8 +89,17 @@ func TestOrganisationService(t *testing.T) {
 
 		org2bis, err := service.GetOrganisation(ctx, org2.ID)
 		assert.NotNil(t, err, "Getting an organisation with deleted parent should return an error")
-		assert.Nil(t, org2bis, "Getting an organisation with deleted parent should return nil for the organisation")
-		assert.ErrorIs(t, err, core.ErrNotFound, "Getting an organisation with deleted parent should return ErrNotFound")
+		assert.Nil(
+			t,
+			org2bis,
+			"Getting an organisation with deleted parent should return nil for the organisation",
+		)
+		assert.ErrorIs(
+			t,
+			err,
+			core.ErrNotFound,
+			"Getting an organisation with deleted parent should return ErrNotFound",
+		)
 	})
 
 	t.Run("ok: list organisation children return only own children", func(t *testing.T) {

--- a/postgres/permission_service.go
+++ b/postgres/permission_service.go
@@ -58,7 +58,7 @@ func (p *PermissionService) CreatePermissionGroup(
 	defer tx.Rollback(ctx) //nolint:errcheck // See tx.Rollback() documentation
 	q := sqlc.New(tx)
 
-	var NewGroup sqlc.ApolloPermissiongroup
+	var NewGroup sqlc.Permissiongroup
 	if Group.ID > 0 {
 		NewGroup, err = q.CreatePermissionGroupWithID(ctx, int32(Group.ID), &Group.Name)
 		if err != nil {
@@ -371,7 +371,7 @@ func (p *PermissionService) GetUserPermissionsForOrganisation(
 }
 
 func combinePermissionGroup(
-	group sqlc.ApolloPermissiongroup,
+	group sqlc.Permissiongroup,
 	perms []sqlc.GetPermissionsForGroupRow,
 ) permissions.PermissionGroup {
 	Name := ""

--- a/postgres/permission_service_test.go
+++ b/postgres/permission_service_test.go
@@ -33,7 +33,7 @@ func CreateUserWithPermissions(
 }
 
 func TestPermissionService(t *testing.T) {
-	db := tests.DB()
+	db := tests.DB(t)
 	service := postgres.NewPermissionService(db)
 	userService := postgres.NewUserService(db)
 	defer tests.DeleteAllPermissions(service)

--- a/postgres/queries/account_cache.sql
+++ b/postgres/queries/account_cache.sql
@@ -1,22 +1,22 @@
 -- name: CreateAccountCache :one
-INSERT INTO apollo.account_cache (name, email, provider, provider_id)
+INSERT INTO account_cache (name, email, provider, provider_id)
     VALUES ($1, $2, $3, $4)
 RETURNING
     *;
 
 -- name: DeleteAccountCache :exec
-DELETE FROM apollo.account_cache
+DELETE FROM account_cache
 WHERE id = $1;
 
 -- name: DeleteAccountCacheOldEntries :exec
-DELETE FROM apollo.account_cache
+DELETE FROM account_cache
 WHERE created < NOW() - $1::interval;
 
 -- name: GetAccountCacheForID :one
 SELECT
     *
 FROM
-    apollo.account_cache
+    account_cache
 WHERE
     id = $1
 LIMIT 1;

--- a/postgres/queries/accounts.sql
+++ b/postgres/queries/accounts.sql
@@ -1,19 +1,19 @@
 -- name: CreateAccount :one
-INSERT INTO apollo.accounts (user_id, provider, provider_id)
+INSERT INTO accounts (user_id, provider, provider_id)
     VALUES ($1, $2, $3)
 RETURNING
     *;
 
 -- name: DeleteAccount :exec
-DELETE FROM apollo.accounts
+DELETE FROM accounts
 WHERE provider = $1 AND provider_id = $2;
 
 -- name: GetUserForProvider :one
 SELECT
     users.*
 FROM
-    apollo.users
-    INNER JOIN apollo.accounts ON users.id = accounts.user_id
+    users
+    INNER JOIN accounts ON users.id = accounts.user_id
 WHERE
     accounts.provider = $1
     AND accounts.provider_id = $2

--- a/postgres/queries/address.sql
+++ b/postgres/queries/address.sql
@@ -2,24 +2,24 @@
 SELECT
 	*
 FROM
-	apollo.address
+	address
 WHERE
 	id = $1
 LIMIT 1;
 
 -- name: CreateAddress :one
-INSERT INTO apollo.address (street, number, extra_line, postal_code, city, country)
+INSERT INTO address (street, number, extra_line, postal_code, city, country)
 	VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING
 	*;
 
 -- name: DeleteAddress :exec
-DELETE FROM apollo.address
+DELETE FROM address
 WHERE id = $1;
 
 -- name: UpdateAddress :one
 UPDATE
-	apollo.address
+	address
 SET
 	street = COALESCE(sqlc.narg(street), street),
 	number = COALESCE(sqlc.narg(number), number),
@@ -36,4 +36,4 @@ RETURNING
 SELECT
 	*
 FROM
-	apollo.address;
+	address;

--- a/postgres/queries/organisations.sql
+++ b/postgres/queries/organisations.sql
@@ -2,7 +2,7 @@
 SELECT
     *
 FROM
-    apollo.organisations
+    organisations
 WHERE
     id = $1
 LIMIT 1;
@@ -11,29 +11,29 @@ LIMIT 1;
 SELECT
     *
 FROM
-    apollo.organisations;
+    organisations;
 
 -- name: GetAmountOfOrganisations :one
 SELECT
     COUNT(id)
 FROM
-    apollo.organisations;
+    organisations;
 
 -- name: CreateOrganisation :one
-INSERT INTO apollo.organisations (name, parent_id)
+INSERT INTO organisations (name, parent_id)
     VALUES ($1, $2)
 RETURNING
     *;
 
 -- name: DeleteOrganisation :exec
-DELETE FROM apollo.organisations
+DELETE FROM organisations
 WHERE id = $1;
 
 -- name: ListOrganisationChildren :many
 SELECT
 	*
 FROM
-	apollo.organisations
+	organisations
 WHERE
 	parent_id = $1;
 
@@ -41,8 +41,8 @@ WHERE
 SELECT
     o.*
 FROM
-    apollo.organisations AS o
-    INNER JOIN apollo.organisation_users AS ou ON o.id = ou.organisation_id
+    organisations AS o
+    INNER JOIN organisation_users AS ou ON o.id = ou.organisation_id
 WHERE
     ou.user_id = $1;
 
@@ -50,17 +50,17 @@ WHERE
 SELECT
     u.*
 FROM
-    apollo.users AS u
-    INNER JOIN apollo.organisation_users AS ou ON u.id = ou.user_id
+    users AS u
+    INNER JOIN organisation_users AS ou ON u.id = ou.user_id
 WHERE
     ou.organisation_id = $1;
 
 -- name: AddUserToOrganisation :exec
-INSERT INTO apollo.organisation_users (user_id, organisation_id)
+INSERT INTO organisation_users (user_id, organisation_id)
     VALUES ($1, $2);
 
 -- name: RemoveUserFromOrganisation :exec
-DELETE FROM apollo.organisation_users
+DELETE FROM organisation_users
 WHERE user_id = $1
     AND organisation_id = $2;
 
@@ -68,6 +68,6 @@ WHERE user_id = $1
 SELECT
     parent_id
 FROM
-    apollo.organisations
+    organisations
 WHERE
     id = $1;

--- a/postgres/queries/permissions.sql
+++ b/postgres/queries/permissions.sql
@@ -1,5 +1,5 @@
 -- name: CreatePermission :exec
-INSERT INTO apollo.permissions (name)
+INSERT INTO permissions (name)
     VALUES ($1)
 ON CONFLICT (name)
     DO NOTHING;
@@ -8,20 +8,20 @@ ON CONFLICT (name)
 SELECT
     permissions.*
 FROM
-    apollo.permissions;
+    permissions;
 
 -- name: ListPermissionGroups :many
 SELECT
     permissiongroups.*
 FROM
-    apollo.permissiongroups;
+    permissiongroups;
 
 -- name: ListPermissionGroupsForUser :many
 SELECT
     pg.*
 FROM
-    apollo.permissiongroups pg
-    INNER JOIN apollo.user_permissiongroup_membership usr ON usr.group_id = pg.id
+    permissiongroups pg
+    INNER JOIN user_permissiongroup_membership usr ON usr.group_id = pg.id
 WHERE
     usr.user_id = $1;
 
@@ -29,47 +29,47 @@ WHERE
 SELECT
     pg.*
 FROM
-    apollo.permissiongroups pg
-    INNER JOIN apollo.organisation_users_permissiongroups org_usr ON org_usr.permission_group_id = pg.id
+    permissiongroups pg
+    INNER JOIN organisation_users_permissiongroups org_usr ON org_usr.permission_group_id = pg.id
 WHERE
-    org_usr.organisation_users_id = (SELECT id FROM apollo.organisation_users WHERE user_id = $1 AND organisation_id = $2);
+    org_usr.organisation_users_id = (SELECT id FROM organisation_users WHERE user_id = $1 AND organisation_id = $2);
 
 -- name: GetPermissionsForGroup :many
 SELECT
     p.name AS permission,
     COALESCE(pgp.enabled, FALSE) AS enabled
 FROM
-    apollo.permissions p
-    LEFT JOIN apollo.permissiongroup_permissions pgp ON p.name = pgp.permission
+    permissions p
+    LEFT JOIN permissiongroup_permissions pgp ON p.name = pgp.permission
         AND pgp.group_id = $1;
 
 -- name: GetPermissionGroup :one
 SELECT
     pg.*
 FROM
-    apollo.permissiongroups pg
+    permissiongroups pg
 WHERE
     pg.id = $1;
 
 -- name: CreatePermissionGroup :one
-INSERT INTO apollo.permissiongroups (name)
+INSERT INTO permissiongroups (name)
     VALUES ($1)
 RETURNING
     *;
 
 -- name: CreatePermissionGroupWithID :one
-INSERT INTO apollo.permissiongroups (id, name)
+INSERT INTO permissiongroups (id, name)
     VALUES ($1, $2)
 RETURNING
     *;
 
 -- name: CreatePermissionGroupPermission :exec
-INSERT INTO apollo.permissiongroup_permissions (group_id, permission, enabled)
+INSERT INTO permissiongroup_permissions (group_id, permission, enabled)
     VALUES ($1, $2, $3);
 
 -- name: RenamePermissionGroup :exec
 UPDATE
-    apollo.permissiongroups
+    permissiongroups
 SET
     name = $2
 WHERE
@@ -77,7 +77,7 @@ WHERE
 
 -- name: UpdatePermissionGroupPermission :exec
 UPDATE
-    apollo.permissiongroup_permissions
+    permissiongroup_permissions
 SET
     enabled = $3
 WHERE
@@ -85,13 +85,13 @@ WHERE
     AND permission = $2;
 
 -- name: AddUserToPermissionGroup :exec
-INSERT INTO apollo.user_permissiongroup_membership (group_id, user_id)
+INSERT INTO user_permissiongroup_membership (group_id, user_id)
     VALUES ($1, $2);
 
 -- name: AddUserToPermissionGroupForOrganisation :exec
-INSERT INTO apollo.organisation_users_permissiongroups (permission_group_id, organisation_users_id)
-    VALUES ($1, (SELECT id FROM apollo.organisation_users WHERE user_id = $2 AND organisation_id = $3));
+INSERT INTO organisation_users_permissiongroups (permission_group_id, organisation_users_id)
+    VALUES ($1, (SELECT id FROM organisation_users WHERE user_id = $2 AND organisation_id = $3));
 
 -- name: DeletePermissionGroup :exec
-DELETE FROM apollo.permissiongroups
+DELETE FROM permissiongroups
 WHERE permissiongroups.id = $1;

--- a/postgres/queries/users.sql
+++ b/postgres/queries/users.sql
@@ -2,7 +2,7 @@
 SELECT
     *
 FROM
-    apollo.users
+    users
 WHERE
     id = $1
 LIMIT 1;
@@ -11,7 +11,7 @@ LIMIT 1;
 SELECT
     *
 FROM
-    apollo.users
+    users
 ORDER BY
     RANDOM();
 
@@ -19,21 +19,21 @@ ORDER BY
 SELECT
     COUNT(*)
 FROM
-    apollo.users;
+    users;
 
 -- name: CreateUser :one
-INSERT INTO apollo.users (name, email)
+INSERT INTO users (name, email)
     VALUES ($1, $2)
 RETURNING
     *;
 
 -- name: DeleteUser :exec
-DELETE FROM apollo.users
+DELETE FROM users
 WHERE id = $1;
 
 -- name: UpdateUserAdmin :exec
 UPDATE
-    apollo.users
+    users
 SET
     admin = $2
 WHERE
@@ -41,7 +41,7 @@ WHERE
 
 -- name: UpdateUser :one
 UPDATE
-    apollo.users
+    users
 SET
     name = COALESCE(sqlc.narg(name), name),
     email = COALESCE(sqlc.narg(email), email)

--- a/postgres/user_service.go
+++ b/postgres/user_service.go
@@ -91,7 +91,7 @@ func (u *UserService) UpdateUser(
 	return convertUser(dbUser)
 }
 
-func convertUser(user sqlc.ApolloUser) (*core.User, error) {
+func convertUser(user sqlc.User) (*core.User, error) {
 	email, err := core.NewEmailAddress(user.Email)
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func convertUser(user sqlc.ApolloUser) (*core.User, error) {
 	}, nil
 }
 
-func convertUserList(users []sqlc.ApolloUser) ([]core.User, error) {
+func convertUserList(users []sqlc.User) ([]core.User, error) {
 	list := make([]core.User, len(users))
 	for i, v := range users {
 		u, err := convertUser(v)

--- a/postgres/user_service_test.go
+++ b/postgres/user_service_test.go
@@ -17,7 +17,7 @@ type CreateUserTest struct {
 }
 
 func TestUserService(t *testing.T) {
-	db := tests.DB()
+	db := tests.DB(t)
 	service := postgres.NewUserService(db)
 	tests.DeleteAllUsers(service)
 	defer tests.DeleteAllUsers(service)

--- a/server/server.go
+++ b/server/server.go
@@ -114,6 +114,10 @@ func (server *Server[state]) WithConfig(cfg *config.Config) *Server[state] {
 	return server
 }
 
+func (server *Server[state]) State() state {
+	return server.state
+}
+
 func (server *Server[state]) NewApollo(w http.ResponseWriter, r *http.Request) *Apollo {
 	apollo := Apollo{
 		Writer:      w,

--- a/server/server.go
+++ b/server/server.go
@@ -114,10 +114,6 @@ func (server *Server[state]) WithConfig(cfg *config.Config) *Server[state] {
 	return server
 }
 
-func (server *Server[state]) State() state {
-	return server.state
-}
-
 func (server *Server[state]) NewApollo(w http.ResponseWriter, r *http.Request) *Apollo {
 	apollo := Apollo{
 		Writer:      w,

--- a/tests/postgres.go
+++ b/tests/postgres.go
@@ -24,18 +24,11 @@ func DB(t *testing.T) *postgres.DB {
 		log.Printf("Could not load the .env file: %v", err)
 	}
 	url := os.Getenv("DATABASE_URL")
-	db, err := postgres.NewDB(ctx, url)
-	if err != nil {
-		t.Fatal(
-			"To test database functionality, set the DATABASE_URL env variable to a valid database",
-		)
-	}
-
 	dbid := rand.Int32()
 	schema := fmt.Sprintf("tests_%v", dbid)
-	err = db.SwitchSchema(ctx, schema)
+	db, err := postgres.NewDB(ctx, url, schema)
 	if err != nil {
-		t.Fatalf("Cannot change to test schema: %v", err)
+		t.Fatalf("Could not create database connection: %v", err)
 	}
 
 	err = db.Migrate(nil, "")


### PR DESCRIPTION
## This PR will:
- Create a "combinedFS" filesystem that reads from two other filesystems as if they were one
- Run all app and apollo migrations together using a combinedFS
- Actually use the config database_schema variable to set the application schema (instead of hard coding these)
- Update all migrations and queries to remove the hardcoded schema

Note that this will break all database that were previously using the split system. There is no easy way around this other than just dropping the entire database and recreating it.

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
