### PR TITLE
Fix csrf render order

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -77,12 +77,13 @@ func (server *Server[state]) CSRFTokenMiddleware() func(http.Handler) http.Handl
 				slog.Error("cannot set csrf cookie", "error", err)
 			}
 
+			next.ServeHTTP(w, r.WithContext(ctx))
+
+			csrfInput(true).Render(ctx, w)
 			err = csrfInput(true).Render(ctx, w)
 			if err != nil {
 				slog.Error("cannot render csrf input", "error", err)
 			}
-
-			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -79,7 +79,6 @@ func (server *Server[state]) CSRFTokenMiddleware() func(http.Handler) http.Handl
 
 			next.ServeHTTP(w, r.WithContext(ctx))
 
-			csrfInput(true).Render(ctx, w)
 			err = csrfInput(true).Render(ctx, w)
 			if err != nil {
 				slog.Error("cannot render csrf input", "error", err)


### PR DESCRIPTION
## This PR will:
- fix the csrf render order
## Checklist:
- [ ] I ran (and extended) the test suite
- [ ] I ran `just lint`
- [ ] I tested both up- and down-migrations
- [ ] I ran `go mod tidy` after changing dependencies
- [ ] I changed the PR title to be more descriptive
- [ ] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
