### PR TITLE
Allow out of order migrations in debug environments

### DIFF
--- a/postgres/database.go
+++ b/postgres/database.go
@@ -82,6 +82,7 @@ func (db *DB) DeleteSchema(ctx context.Context, schema string) error {
 func (db *DB) createGooseProvider(
 	migrations *embed.FS,
 	folder string,
+	isDebug bool,
 ) (*goose.Provider, error) {
 	apollo, err := fs.Sub(embedMigrations, "migrations")
 	if err != nil {
@@ -109,14 +110,15 @@ func (db *DB) createGooseProvider(
 		database,
 		migrateFS,
 		goose.WithVerbose(true), // Enable logging (as with goose.Up)
+		goose.WithAllowOutofOrder(isDebug),
 	)
 }
 
 // Migrate the database using the specified embedded migration folder.
 // "folder" specifies the location of the folder containing sql files within the embed.FS
 // To only run the Apollo migrations, set migrations to nil
-func (db *DB) Migrate(migrations *embed.FS, folder string) error {
-	provider, err := db.createGooseProvider(migrations, folder)
+func (db *DB) Migrate(migrations *embed.FS, folder string, isDebug bool) error {
+	provider, err := db.createGooseProvider(migrations, folder, isDebug)
 	if err != nil {
 		return fmt.Errorf("Cannot create goose provider: %w", err)
 	}
@@ -136,8 +138,8 @@ func (db *DB) Migrate(migrations *embed.FS, folder string) error {
 // Migrate the database down a single step using the specified embedded migration folder.
 // "folder" specifies the location of the folder containing sql files within the embed.FS
 // To only run the Apollo migrations, set migrations to nil
-func (db *DB) MigrateDown(migrations *embed.FS, folder string) error {
-	provider, err := db.createGooseProvider(migrations, folder)
+func (db *DB) MigrateDown(migrations *embed.FS, folder string, isDebug bool) error {
+	provider, err := db.createGooseProvider(migrations, folder, isDebug)
 	if err != nil {
 		return fmt.Errorf("Cannot create goose provider: %w", err)
 	}

--- a/tests/postgres.go
+++ b/tests/postgres.go
@@ -31,7 +31,7 @@ func DB(t *testing.T) *postgres.DB {
 		t.Fatalf("Could not create database connection: %v", err)
 	}
 
-	err = db.Migrate(nil, "")
+	err = db.Migrate(nil, "", true)
 	if err != nil {
 		log.Panicf("Cannot migrate apollo db: %v", err)
 	}


### PR DESCRIPTION
## This PR will:
- Allow out of order migrations in debug environments, this should reduce the amount of issues when switching between PR branches

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
