### PR TITLE
Use server config when building urls to strip trailing slashes

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -162,7 +162,7 @@ func (server *Server[state]) handleMiddleware(
 
 func (server *Server[state]) AttachDefaultMiddleware() {
 	server.UseStd(
-		middleware.RedirectSlashes, // The FileServer warning should be irrelevant for our applications, but there might be edge cases where this does cause problems.
+		server.RedirectSlashes,
 		middleware.Recoverer,
 		middleware.RealIP,
 		middleware.RequestID,


### PR DESCRIPTION
## This PR will:
- Use server config when building urls to strip trailing slashes
- Fix an issue with trailing slashes in deployments that use part of the path for routing to a container (such as our preview deployments)

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
