### PR TITLE
Fix multiple (minor) things

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -69,7 +69,7 @@ func Full[state BootstrappedState[state]](
 	stt state,
 	cfg *config.Config,
 	staticFS embed.FS,
-	middlewares ...func(http.Handler) http.Handler,
+	middlewares ...server.Middleware[state],
 ) *server.Server[state] {
 	if cfg == nil {
 		panic("You need to supply a config.Config value to bootstrap a new server")
@@ -111,7 +111,7 @@ func Full[state BootstrappedState[state]](
 		s.UseStd(middleware.NoCache)
 	}
 
-	s.UseStd(middlewares...)
+	s.Use(middlewares...)
 
 	s.StaticFiles("/static", "static", staticFS)
 	s.StaticFiles(

--- a/core/id.go
+++ b/core/id.go
@@ -23,9 +23,5 @@ func ParseID(id string) (ID, error) {
 	if integerID < 0 {
 		return 0, errors.New("cannot parse  id:  ids cannot be negative")
 	}
-	ID := ID(int32(integerID))
-	if err != nil {
-		return 0, fmt.Errorf("cannot parse  id: %w", err)
-	}
-	return ID, nil
+	return ID(int32(integerID)), nil
 }

--- a/server/context.go
+++ b/server/context.go
@@ -16,6 +16,7 @@ const (
 	ctxUserName
 	ctxOrganisationID
 	ctxOrganisationName
+	ctxOrganisationParent
 	ctxSession
 	ctxConfig
 	ctxIsAdmin
@@ -51,6 +52,14 @@ func OrganisationID(ctx context.Context) core.OrganisationID {
 
 func OrganisationName(ctx context.Context) string {
 	return ctx.Value(ctxOrganisationName).(string)
+}
+
+func OrganisationParentID(ctx context.Context) *core.OrganisationID {
+	id, ok := ctx.Value(ctxOrganisationParent).(core.OrganisationID)
+	if !ok {
+		return nil
+	}
+	return &id
 }
 
 // Session provides access to the current user's session.

--- a/server/context.go
+++ b/server/context.go
@@ -8,6 +8,8 @@ import (
 	"github.com/prior-it/apollo/core"
 )
 
+type contextKey uint
+
 const (
 	ctxLoggedIn contextKey = iota
 	ctxUserID
@@ -37,6 +39,10 @@ func UserID(ctx context.Context) core.UserID {
 
 func UserName(ctx context.Context) string {
 	return ctx.Value(ctxUserName).(string)
+}
+
+func HasActiveOrganisation(ctx context.Context) bool {
+	return ctx.Value(ctxOrganisationID) != nil
 }
 
 func OrganisationID(ctx context.Context) core.OrganisationID {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -172,6 +172,21 @@ func (server *Server[state]) SessionMiddleware() func(http.Handler) http.Handler
 				ctx = context.WithValue(ctx, ctxUserID, userID)
 			}
 
+			organisationID, ok := session.Values[sessionOrganisationID].(core.OrganisationID)
+			if ok {
+				ctx = context.WithValue(ctx, ctxOrganisationID, organisationID)
+			}
+
+			organisationName, ok := session.Values[sessionOrganisationName].(string)
+			if ok {
+				ctx = context.WithValue(ctx, ctxOrganisationName, organisationName)
+			}
+
+			organisationParent, ok := session.Values[sessionOrganisationParent].(core.OrganisationID)
+			if ok {
+				ctx = context.WithValue(ctx, ctxOrganisationParent, organisationParent)
+			}
+
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -31,7 +31,7 @@ func RequireLogin[state any](apollo *Apollo, _ state) (context.Context, error) {
 	return apollo.Context(), apollo.RequiresLogin()
 }
 
-func isStaticFile(path string) bool {
+func IsStaticFile(path string) bool {
 	return strings.HasPrefix(path, "/static/") || strings.HasPrefix(path, "/apollo/")
 }
 
@@ -43,7 +43,7 @@ func (server *Server[state]) RedirectSlashes(next http.Handler) http.Handler {
 		path := r.URL.Path
 		// NOTE: Ignore static files since this method does not work with FileServer,
 		// see https://github.com/go-chi/chi/issues/343
-		if !isStaticFile(path) && len(path) > 1 && path[len(path)-1] == '/' {
+		if !IsStaticFile(path) && len(path) > 1 && path[len(path)-1] == '/' {
 			if r.URL.RawQuery != "" {
 				path = fmt.Sprintf("%s?%s", path[:len(path)-1], r.URL.RawQuery)
 			} else {
@@ -69,7 +69,7 @@ func (server *Server[state]) CSRFTokenMiddleware() func(http.Handler) http.Handl
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if isStaticFile(r.URL.Path) {
+			if IsStaticFile(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -148,7 +148,7 @@ func (server *Server[state]) handle(handler Handler[state]) http.HandlerFunc {
 func ConvertToApolloMiddleware[state State](
 	middleware func(w http.ResponseWriter, r *http.Request),
 ) Middleware[state] {
-	return func(apollo *Apollo, s state) (context.Context, error) {
+	return func(apollo *Apollo, _ state) (context.Context, error) {
 		middleware(apollo.Writer, apollo.Request)
 		return apollo.Context(), nil
 	}
@@ -366,6 +366,17 @@ func (server *Server[state]) Page(
 ) *Server[state] {
 	server.mux.Get(pattern, server.handle(func(apollo *Apollo, _ state) error {
 		return apollo.RenderPage(component, options)
+	}))
+	return server
+}
+
+// Component adds the route `pattern` that matches a GET http method to render the specified templ component without any layout.
+func (server *Server[state]) Component(
+	pattern string,
+	component templ.Component,
+) *Server[state] {
+	server.mux.Get(pattern, server.handle(func(apollo *Apollo, _ state) error {
+		return apollo.RenderComponent(component)
 	}))
 	return server
 }

--- a/server/session.go
+++ b/server/session.go
@@ -10,8 +10,6 @@ import (
 	"github.com/prior-it/apollo/core"
 )
 
-type contextKey uint
-
 const (
 	cookieUser = "apollo-user"
 	cookieCSRF = "apollo-csrf"


### PR DESCRIPTION
## This PR will:
- Remove an unnecessary error check in core.ParseID
- Add an active organisation check to the apollo context since simply retrieving the organisation if there is none is a segfault
- Change the bootstrapping functions to take Apollo middleware instead of stdlib middleware
- Add utility functions that can convert between apollo <> stdlib middleware
- Move the contextKey definition to the correct file 
- Make server.IsStaticFile public so application middleware can use the same check
- Add a method that simply renders a component as-is, without layout
- Change the CSRF middleware to only render updated inputs on HTMX requests

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
