### PR TITLE
Make it possible to rebuild the apollo context within a request if the session changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 // indirect
 	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/sys v0.23.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
-golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
 golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/server/apollo.go
+++ b/server/apollo.go
@@ -34,11 +34,13 @@ type Apollo struct {
 	Organisation *core.Organisation
 	permissions  permissions.Service
 	store        sessions.Store
+	ctx          context.Context
 }
 
 // Populate populates the Apollo object with fields that need to be retrieved after initialisation.
 // E.g. fields that are stored in the active session.
 func (apollo *Apollo) populate() {
+	apollo.ctx = apollo.Request.Context()
 	if apollo.store != nil {
 		apollo.populateUser()
 		apollo.populateOrganisation()
@@ -139,7 +141,15 @@ func (apollo *Apollo) LogField(field string, value slog.Value) {
 // client's connection closes, the request is canceled (with HTTP/2),
 // or when the ServeHTTP method returns.
 func (apollo *Apollo) Context() context.Context {
-	return apollo.Request.Context()
+	return apollo.ctx
+}
+
+// RebuildContext rebuilds the apollo context based on the current session data.
+func (apollo *Apollo) rebuildContext() {
+	ctx := apollo.ctx
+	session := apollo.Session()
+	ctx = buildSessionContext(ctx, session)
+	apollo.ctx = ctx
 }
 
 // Host specifies the host on which the URL is sought.

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -138,8 +138,6 @@ func (server *Server[state]) ContextMiddleware(next http.Handler) http.Handler {
 
 // SessionMiddleware returns the Apollo session middleware.
 // Attach this before adding routes, if you want to use sessions.
-//
-//nolint:cyclop
 func (server *Server[state]) SessionMiddleware() func(http.Handler) http.Handler {
 	if server.sessionStore == nil {
 		slog.Warn("Not enabling the SessionMiddleware since there is no SessionStore configured")
@@ -162,37 +160,7 @@ func (server *Server[state]) SessionMiddleware() func(http.Handler) http.Handler
 			}
 
 			ctx = context.WithValue(ctx, ctxSession, session)
-
-			loggedIn, ok := session.Values[sessionLoggedIn].(bool)
-			ctx = context.WithValue(ctx, ctxLoggedIn, ok && loggedIn)
-
-			isAdmin, ok := session.Values[sessionIsAdmin].(bool)
-			ctx = context.WithValue(ctx, ctxIsAdmin, ok && isAdmin)
-
-			userName, ok := session.Values[sessionUserName].(string)
-			if ok {
-				ctx = context.WithValue(ctx, ctxUserName, userName)
-			}
-
-			userID, ok := session.Values[sessionUserID].(core.UserID)
-			if ok {
-				ctx = context.WithValue(ctx, ctxUserID, userID)
-			}
-
-			organisationID, ok := session.Values[sessionOrganisationID].(core.OrganisationID)
-			if ok {
-				ctx = context.WithValue(ctx, ctxOrganisationID, organisationID)
-			}
-
-			organisationName, ok := session.Values[sessionOrganisationName].(string)
-			if ok {
-				ctx = context.WithValue(ctx, ctxOrganisationName, organisationName)
-			}
-
-			organisationParent, ok := session.Values[sessionOrganisationParent].(core.OrganisationID)
-			if ok {
-				ctx = context.WithValue(ctx, ctxOrganisationParent, organisationParent)
-			}
+			ctx = buildSessionContext(ctx, session)
 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})


### PR DESCRIPTION
session changes for some reason

## This PR will:
- Make it possible to rebuild apollo.Context() within a single request, e.g. after changing the session
- No longer make it required to refresh after changing something in the session

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
