### PR TITLE
Fix ubuntu runner problems

### DIFF
--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -226,7 +226,7 @@ func createCommands(
 		ctx,
 		"application",
 		lipgloss.NewStyle(),
-		false,
+		true,
 		false, // don't run at start, wait for the first compile to finish
 		"%v/main",
 		cfg.Tools.BuildDir,
@@ -313,7 +313,7 @@ func startRunner(
 		<-sigs
 
 		if debug {
-			outChan <- "Received shutdown signal\n"
+			outChan <- "Received shutdown signal"
 		}
 
 		// Give the subprocesses some time to exit gracefully

--- a/config/config.go
+++ b/config/config.go
@@ -69,8 +69,8 @@ type AppConfig struct {
 	Host                   string
 	URL                    string
 	Name                   string
-	ShutdownTimeout        float32 `default:"1.5"` // in seconds
-	Env                    AppEnv  `default:"production"`
+	ShutdownTimeout        int32  `default:"2"` // in seconds
+	Env                    AppEnv `default:"production"`
 	Version                string
 	RequestTimeout         uint32 `default:"30"` // in seconds
 	AuthenticationKey      string `                     mapstructure:"AUTHKEY"`

--- a/server/server.go
+++ b/server/server.go
@@ -237,9 +237,12 @@ loop:
 		ctx,
 		time.Duration(server.cfg.App.ShutdownTimeout)*time.Second,
 	)
-	defer cancelShutdown()
 
-	go server.Shutdown(ctxShutdown)
+	go func() {
+		defer cancelShutdown()
+
+		server.Shutdown(ctxShutdown)
+	}()
 
 	<-ctxShutdown.Done()
 


### PR DESCRIPTION
## This PR will:
- Add more debugging output to help diagnose issues
- Make sure servers can exit sooner if they're finished before the shutdown timeout has completed
- Always sigkill the application process
- Add a mutex around the restart call so it can't run more than once at a time if someone spams the `r` button

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
