### PR TITLE
Add a very basic feature flag configuration and middleware

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	Log            LogConfig
 	OAuthProviders map[string]OauthProviderConfig `mapstructure:"OAUTH"`
 	Tools          ToolsConfig
+	Features       FeaturesConfig
 }
 
 type AppConfig struct {
@@ -125,6 +126,11 @@ type ToolsConfig struct {
 	BuildDir    string `default:"./tmp"`
 	IgnoreDirs  []string
 	OpenBrowser bool
+}
+
+type FeaturesConfig struct {
+	EnableAll bool
+	Flags     map[string]bool
 }
 
 func (c Config) BaseURL() string {

--- a/server/context.go
+++ b/server/context.go
@@ -22,7 +22,22 @@ const (
 	ctxIsAdmin
 	ctxNewCSRFToken
 	ctxOldCSRFToken
+	ctxFlags
+	ctxEnableAll
 )
+
+func allFeatureFlagsEnabled(ctx context.Context) bool {
+	v, ok := ctx.Value(ctxEnableAll).(bool)
+	return ok && v
+}
+
+func HasFeature(ctx context.Context, feature string) bool {
+	if allFeatureFlagsEnabled(ctx) {
+		return true
+	}
+	v, ok := ctx.Value(ctxFlags).(map[string]bool)
+	return ok && v[feature]
+}
 
 func IsLoggedIn(ctx context.Context) bool {
 	loggedIn, ok := ctx.Value(ctxLoggedIn).(bool)

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -167,6 +167,17 @@ func (server *Server[state]) SessionMiddleware() func(http.Handler) http.Handler
 	}
 }
 
+func (server *Server[state]) FeatureFlagMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		ctx = context.WithValue(ctx, ctxFlags, server.cfg.Features.Flags)
+		ctx = context.WithValue(ctx, ctxEnableAll, server.cfg.Features.EnableAll)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 // Debug is middleware that can be inserted anywhere and will print some useful debug information about the current
 // request.
 func Debug(printFullRequest bool) func(http.Handler) http.Handler {

--- a/server/middleware_test.go
+++ b/server/middleware_test.go
@@ -1,0 +1,115 @@
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prior-it/apollo/config"
+	"github.com/prior-it/apollo/server"
+	"github.com/stretchr/testify/assert"
+)
+
+type State struct{}
+
+func (s State) Close(_ context.Context) {}
+
+func runTest(cfg *config.Config, testfunc func(ctx context.Context)) {
+	s := server.New(State{}, cfg)
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", strings.NewReader(""))
+
+	s.FeatureFlagMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		testfunc(r.Context())
+	})).ServeHTTP(recorder, req)
+}
+
+func TestFeatureFlagMiddleware(t *testing.T) {
+	t.Run("ok: feature flags are followed", func(t *testing.T) {
+		t.Parallel()
+		runTest(
+			&config.Config{
+				Features: config.FeaturesConfig{
+					Flags: map[string]bool{
+						"FEATURE1": true,
+						"FEATURE2": false,
+					},
+				},
+			},
+			func(ctx context.Context) {
+				assert.True(t, server.HasFeature(ctx, "FEATURE1"))
+				assert.False(t, server.HasFeature(ctx, "FEATURE2"))
+				assert.False(
+					t,
+					server.HasFeature(ctx, "FEATURE3"),
+					"A feature that does not exist should return false",
+				)
+			},
+		)
+	})
+
+	t.Run("ok: enable all overrides specific flags", func(t *testing.T) {
+		t.Parallel()
+		runTest(
+			&config.Config{
+				Features: config.FeaturesConfig{
+					EnableAll: true,
+					Flags: map[string]bool{
+						"FEATURE":      true,
+						"OTHERFEATURE": false,
+					},
+				},
+			},
+			func(ctx context.Context) {
+				assert.True(t, server.HasFeature(ctx, "FEATURE"))
+				assert.True(t, server.HasFeature(ctx, "OTHERFEATURE"))
+			},
+		)
+	})
+
+	t.Run("ok: enable all overrides unspecified flags", func(t *testing.T) {
+		t.Parallel()
+		runTest(
+			&config.Config{
+				Features: config.FeaturesConfig{
+					EnableAll: true,
+					Flags:     map[string]bool{},
+				},
+			},
+			func(ctx context.Context) {
+				assert.True(t, server.HasFeature(ctx, "SOMEFEATURE"))
+				assert.True(t, server.HasFeature(ctx, "SOMEOTHERFEATURE"))
+			},
+		)
+	})
+
+	t.Run(
+		"ok: all feature flags return false if the feature flag middleware was not added",
+		func(t *testing.T) {
+			t.Parallel()
+			cfg := &config.Config{
+				Features: config.FeaturesConfig{
+					EnableAll: true,
+					Flags: map[string]bool{
+						"NOFEATURE1": true,
+						"NOFEATURE2": true,
+					},
+				},
+			}
+
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/", strings.NewReader(""))
+			s := server.New(State{}, cfg)
+			s.ContextMiddleware( // Use context middleware to test in an environment where cfg does exist in the context
+				http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+					ctx := r.Context()
+					assert.False(t, server.HasFeature(ctx, "NOFEATURE1"))
+					assert.False(t, server.HasFeature(ctx, "NOFEATURE2"))
+				}),
+			).
+				ServeHTTP(recorder, req)
+		},
+	)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -187,6 +187,7 @@ func (server *Server[state]) AttachDefaultMiddleware() {
 		server.CSRFTokenMiddleware(),
 		// @TODO: Page caching
 		server.ContextMiddleware,
+		server.FeatureFlagMiddleware,
 	)
 }
 


### PR DESCRIPTION
## This PR will:
- Add a basic feature flag system by extending the existing config system

We will probably add support for PostHog feature flags to this in a later PR, but this system suffices for now for our internal use-cases.

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
