### PR TITLE
Fix i18n logging

### DIFF
--- a/server/i18n.go
+++ b/server/i18n.go
@@ -44,13 +44,6 @@ func DetectLanguage[state any](apollo *Apollo, _ state) (context.Context, error)
 
 	lang := apollo.Request.Header.Get("Accept-Language")
 
-	// This is here for logging, ctxi18n should already use the fallback if lang is empty
-	if len(lang) == 0 {
-		lang = apollo.Cfg.App.FallbackLang
-	}
-
-	apollo.LogField("lang", slog.StringValue(lang))
-
 	ctx, err := ctxi18n.WithLocale(ctx, lang)
 	if errors.Is(err, ctxi18n.ErrMissingLocale) {
 		err = fmt.Errorf(
@@ -60,5 +53,12 @@ func DetectLanguage[state any](apollo *Apollo, _ state) (context.Context, error)
 		)
 	}
 
+	apollo.LogField("lang", slog.StringValue(string(ctxi18n.Locale(ctx).Code())))
+
 	return ctx, err
+}
+
+// Return the 2-letter code for the language that is currently active
+func Language(ctx context.Context) string {
+	return string(ctxi18n.Locale(ctx).Code())
 }


### PR DESCRIPTION
## This PR will:
- Log the field that will actually be used instead of our best guess
- Add a function that returns the currently active language code

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
