### PR TITLE
Inject a pointer to the Apollo object in the context

### DIFF
--- a/server/apollo.go
+++ b/server/apollo.go
@@ -42,6 +42,7 @@ type Apollo struct {
 // E.g. fields that are stored in the active session.
 func (apollo *Apollo) populate() {
 	apollo.ctx = apollo.Request.Context()
+
 	if apollo.store != nil {
 		apollo.populateUser()
 		apollo.populateOrganisation()
@@ -91,6 +92,20 @@ func (apollo *Apollo) populateOrganisation() {
 		apollo.Organisation = organisation
 		apollo.LogField("active_organisation_id", slog.AnyValue(apollo.Organisation.ID))
 	}
+}
+
+func InjectApollo[state any](apollo *Apollo, _ state) (context.Context, error) {
+	ctx := apollo.Context()
+	ctx = context.WithValue(ctx, ctxApollo, apollo)
+	return ctx, nil
+}
+
+func Ap(ctx context.Context) *Apollo {
+	apollo, ok := ctx.Value(ctxApollo).(*Apollo)
+	if !ok {
+		panic("You need to inject the apollo object in the context before you can retrieve it")
+	}
+	return apollo
 }
 
 func (apollo *Apollo) StatusCode(code int) {

--- a/server/context.go
+++ b/server/context.go
@@ -18,6 +18,7 @@ const (
 	ctxOrganisationName
 	ctxOrganisationParent
 	ctxSession
+	ctxApollo
 	ctxConfig
 	ctxIsAdmin
 	ctxNewCSRFToken

--- a/server/server.go
+++ b/server/server.go
@@ -188,6 +188,7 @@ func (server *Server[state]) AttachDefaultMiddleware() {
 		// @TODO: Page caching
 		server.ContextMiddleware,
 		server.FeatureFlagMiddleware,
+		server.MiddlewareHandler(InjectApollo),
 		server.MiddlewareHandler(DetectLanguage),
 	)
 }


### PR DESCRIPTION
## This PR will:
- Inject a pointer to the Apollo object in the context

This pointer is especially useful for permission checks in templ templates.

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
