### PR TITLE
Update the permission group id sequence after inserting a group with a hard-coded id

### DIFF
--- a/postgres/internal/sqlc/permissions.sql.go
+++ b/postgres/internal/sqlc/permissions.sql.go
@@ -21,7 +21,14 @@ func (q *Queries) AddUserToPermissionGroup(ctx context.Context, groupID int32, u
 
 const addUserToPermissionGroupForOrganisation = `-- name: AddUserToPermissionGroupForOrganisation :exec
 INSERT INTO organisation_users_permissiongroups (permission_group_id, organisation_users_id)
-    VALUES ($1, (SELECT id FROM organisation_users WHERE user_id = $2 AND organisation_id = $3))
+    VALUES ($1, (
+            SELECT
+                id
+            FROM
+                organisation_users
+            WHERE
+                user_id = $2
+                AND organisation_id = $3))
 `
 
 type AddUserToPermissionGroupForOrganisationParams struct {
@@ -216,7 +223,14 @@ FROM
     permissiongroups pg
     INNER JOIN organisation_users_permissiongroups org_usr ON org_usr.permission_group_id = pg.id
 WHERE
-    org_usr.organisation_users_id = (SELECT id FROM organisation_users WHERE user_id = $1 AND organisation_id = $2)
+    org_usr.organisation_users_id = (
+        SELECT
+            id
+        FROM
+            organisation_users
+        WHERE
+            user_id = $1
+            AND organisation_id = $2)
 `
 
 func (q *Queries) ListPermissionGroupsForUserForOrganisation(ctx context.Context, userID int32, organisationID int32) ([]Permissiongroup, error) {
@@ -277,6 +291,19 @@ WHERE
 
 func (q *Queries) RenamePermissionGroup(ctx context.Context, iD int32, name *string) error {
 	_, err := q.db.Exec(ctx, renamePermissionGroup, iD, name)
+	return err
+}
+
+const updatePermissionGroupIndex = `-- name: UpdatePermissionGroupIndex :exec
+SELECT
+    SETVAL('permissiongroups_id_seq', (
+            SELECT
+                MAX(id)
+            FROM permissiongroups))
+`
+
+func (q *Queries) UpdatePermissionGroupIndex(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, updatePermissionGroupIndex)
 	return err
 }
 

--- a/postgres/permission_service.go
+++ b/postgres/permission_service.go
@@ -68,6 +68,14 @@ func (p *PermissionService) CreatePermissionGroup(
 				ConvertPgError(err),
 			)
 		}
+		err = q.UpdatePermissionGroupIndex(ctx)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"could not update the permission group index after adding id %v: %w",
+				Group.ID,
+				ConvertPgError(err),
+			)
+		}
 
 	} else {
 		NewGroup, err = q.CreatePermissionGroup(ctx, &Group.Name)

--- a/postgres/queries/permissions.sql
+++ b/postgres/queries/permissions.sql
@@ -32,7 +32,14 @@ FROM
     permissiongroups pg
     INNER JOIN organisation_users_permissiongroups org_usr ON org_usr.permission_group_id = pg.id
 WHERE
-    org_usr.organisation_users_id = (SELECT id FROM organisation_users WHERE user_id = $1 AND organisation_id = $2);
+    org_usr.organisation_users_id = (
+        SELECT
+            id
+        FROM
+            organisation_users
+        WHERE
+            user_id = $1
+            AND organisation_id = $2);
 
 -- name: GetPermissionsForGroup :many
 SELECT
@@ -63,6 +70,13 @@ INSERT INTO permissiongroups (id, name)
 RETURNING
     *;
 
+-- name: UpdatePermissionGroupIndex :exec
+SELECT
+    SETVAL('permissiongroups_id_seq', (
+            SELECT
+                MAX(id)
+            FROM permissiongroups));
+
 -- name: CreatePermissionGroupPermission :exec
 INSERT INTO permissiongroup_permissions (group_id, permission, enabled)
     VALUES ($1, $2, $3);
@@ -90,7 +104,14 @@ INSERT INTO user_permissiongroup_membership (group_id, user_id)
 
 -- name: AddUserToPermissionGroupForOrganisation :exec
 INSERT INTO organisation_users_permissiongroups (permission_group_id, organisation_users_id)
-    VALUES ($1, (SELECT id FROM organisation_users WHERE user_id = $2 AND organisation_id = $3));
+    VALUES ($1, (
+            SELECT
+                id
+            FROM
+                organisation_users
+            WHERE
+                user_id = $2
+                AND organisation_id = $3));
 
 -- name: DeletePermissionGroup :exec
 DELETE FROM permissiongroups


### PR DESCRIPTION
## This PR will:
- Update the permission group id sequence after inserting a group with a hard-coded id

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
