### PR TITLE
check feature flags in lower and upper case

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"strings"
 
 	"github.com/gorilla/sessions"
 	"github.com/prior-it/apollo/config"
@@ -37,7 +38,7 @@ func HasFeature(ctx context.Context, feature string) bool {
 		return true
 	}
 	v, ok := ctx.Value(ctxFlags).(map[string]bool)
-	return ok && v[feature]
+	return ok && (v[strings.ToLower(feature)] || v[strings.ToUpper(feature)])
 }
 
 func IsLoggedIn(ctx context.Context) bool {


### PR DESCRIPTION
## This PR will:
- feature flags did not work because (at least on my system) the feature map contained the feature keys as lowercase strings, whereas the code checks on the existence of uppercase keys. This PR checks for both lower and uppercase for more robustness

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [ ] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [ ] I used `git rebase -i` to clean up the commit history in this branch
