### PR TITLE
Attach Sentry middleware if Sentry is enabled

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -162,8 +162,9 @@ func initSentry(logger *slog.Logger, cfg *config.Config) {
 			}
 			return 1.0
 		}),
+		DebugWriter:        os.Stdout,
 		ProfilesSampleRate: cfg.Sentry.ProfilesRate,
-		ServerName:         cfg.App.Name,
+		ServerName:         cfg.App.URL,
 		Release:            cfg.App.Version,
 		Environment:        string(cfg.App.Env),
 	}); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/a-h/templ"
 	"github.com/getsentry/sentry-go"
+	sentryhttp "github.com/getsentry/sentry-go/http"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
@@ -172,6 +173,12 @@ func (server *Server[state]) MiddlewareHandler(
 }
 
 func (server *Server[state]) AttachDefaultMiddleware() {
+	if server.cfg.Sentry.Enabled {
+		sentryHandler := sentryhttp.New(sentryhttp.Options{
+			Repanic: true,
+		})
+		server.UseStd(sentryHandler.Handle)
+	}
 	server.UseStd(
 		server.RedirectSlashes,
 		middleware.Recoverer,


### PR DESCRIPTION
## This PR will:
- Attach the Sentry middleware if Sentry is enabled

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
