### PR TITLE
Add support for sending emails through SMTP

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	App            AppConfig
 	Sentry         SentryConfig
 	PostHog        PostHogConfig
+	Email          EmailConfig
 	Database       DatabaseConfig
 	Log            LogConfig
 	OAuthProviders map[string]OauthProviderConfig `mapstructure:"OAUTH"`
@@ -97,9 +98,20 @@ type PostHogConfig struct {
 	Endpoint string
 }
 
+type EmailConfig struct {
+	Host     string
+	Port     int
+	User     string
+	Password string
+	From     string
+	// Email address to send notifications to
+	Notifications string
+}
+
 type DatabaseConfig struct {
-	URL    string
-	Schema string `default:"public"`
+	URL              string
+	Schema           string `default:"public"`
+	MigrateOnStartup bool
 }
 
 type LogConfig struct {

--- a/core/email.go
+++ b/core/email.go
@@ -1,10 +1,19 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/mail"
 	"strings"
+
+	"github.com/a-h/templ"
+	"gopkg.in/gomail.v2"
+)
+
+var (
+	ErrInvalidEmailAddress = errors.New("invalid e-mail address")
+	ErrEmailAddressEmpty   = errors.New("e-mail address is empty")
 )
 
 type EmailAddress interface {
@@ -24,12 +33,38 @@ func (email emailAddress) String() string {
 // This uses RFC-5322 to determine valid e-mail addresses, e.g. "Biggie Smalls <notorious@example.com>"
 func NewEmailAddress(address string) (EmailAddress, error) {
 	if len(address) == 0 {
-		return nil, errors.New("e-mail address cannot be empty")
+		return nil, errors.Join(ErrInvalidEmailAddress, ErrEmailAddressEmpty)
 	}
 	address = strings.ToLower(address)
 	_, err := mail.ParseAddress(address)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse e-mail address %q: %w", address, err)
+		return nil, errors.Join(
+			ErrInvalidEmailAddress,
+			fmt.Errorf("cannot parse e-mail address %q: %w", address, err),
+		)
 	}
 	return emailAddress{address}, nil
+}
+
+type EmailService interface {
+	// SendEmail will build and send a basic e-mail message containing both a HTML template version
+	// (optional) as well as a plaintext alternative (required).
+	SendEmail(
+		ctx context.Context,
+		address EmailAddress,
+		subject string,
+		template *templ.Component,
+		plaintextMessage string,
+	) error
+
+	// SendNotification will send a specific plain-text notification to the configured notification
+	// address.
+	SendNotification(
+		ctx context.Context,
+		subject string,
+		message string,
+	) error
+
+	// SendRawMessage will send a raw gomail message using the existing configuration.
+	SendRawMessage(ctx context.Context, message *gomail.Message) error
 }

--- a/core/email.go
+++ b/core/email.go
@@ -63,6 +63,7 @@ type EmailService interface {
 		ctx context.Context,
 		subject string,
 		message string,
+		args ...any,
 	) error
 
 	// SendRawMessage will send a raw gomail message using the existing configuration.

--- a/go.mod
+++ b/go.mod
@@ -28,9 +28,13 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	github.com/vearutop/statigz v1.4.3
+	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 )
 
-require github.com/invopop/yaml v0.2.0 // indirect
+require (
+	github.com/invopop/yaml v0.2.0 // indirect
+	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
+)
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -206,10 +206,14 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df h1:n7WqCuqOuCbNr617RXOY0AWRXxgwEyPp2z+p0+hgMuE=
+gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df/go.mod h1:LRQQ+SO6ZHR7tOkpBDuZnXENFzX8qRjMDMyPD6BRkCw=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=

--- a/postgres/organisation_service_test.go
+++ b/postgres/organisation_service_test.go
@@ -148,7 +148,7 @@ func TestOrganisationService(t *testing.T) {
 		// List without users
 		users, err := service.ListUsersInOrganisation(ctx, organisation.ID)
 		assert.Nil(t, err, "Getting users in organisation should not error")
-		assert.Len(t, users, 0, "Users list shoud be empty")
+		assert.Len(t, users, 0, "Users list should be empty")
 
 		// Add user to organisation
 		email, err := core.NewEmailAddress("getuserok@example.com")
@@ -161,14 +161,14 @@ func TestOrganisationService(t *testing.T) {
 		// List with user in organisation
 		users, err = service.ListUsersInOrganisation(ctx, organisation.ID)
 		assert.Nil(t, err, "Getting users in organisation should not error")
-		assert.NotEmpty(t, users, "Users list shoud not be empty")
+		assert.NotEmpty(t, users, "Users list should not be empty")
 		assert.Equal(t, users[0], *user)
 
 		// Remove user from organisation
 		tests.Check(service.RemoveUser(ctx, user.ID, organisation.ID))
 		users, err = service.ListUsersInOrganisation(ctx, organisation.ID)
 		assert.Nil(t, err, "Getting users in organisation should not error")
-		assert.Len(t, users, 0, "Users list shoud be empty")
+		assert.Len(t, users, 0, "Users list should be empty")
 	})
 
 	t.Run("ok: deleting user removes user from organisation", func(t *testing.T) {
@@ -188,6 +188,6 @@ func TestOrganisationService(t *testing.T) {
 		tests.Check(UserService.DeleteUser(ctx, user.ID))
 		users, err := service.ListUsersInOrganisation(ctx, organisation.ID)
 		assert.Nil(t, err, "Getting users in organisation should not error")
-		assert.Len(t, users, 0, "Users list shoud be empty")
+		assert.Len(t, users, 0, "Users list should be empty")
 	})
 }

--- a/smtp/doc.go
+++ b/smtp/doc.go
@@ -1,0 +1,2 @@
+// Package smtp provides implementations of services for sending e-mails using an SMTP server
+package smtp

--- a/smtp/email_service.go
+++ b/smtp/email_service.go
@@ -3,6 +3,7 @@ package smtp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"log/slog"
 	"strings"
@@ -79,6 +80,7 @@ func (s *EmailService) SendNotification(
 	ctx context.Context,
 	subject string,
 	message string,
+	args ...any,
 ) error {
 	if s.notifications == nil {
 		return core.ErrEmailAddressEmpty
@@ -88,7 +90,7 @@ func (s *EmailService) SendNotification(
 		*s.notifications,
 		subject,
 		nil,
-		message,
+		fmt.Sprintf(message, args...),
 	)
 }
 

--- a/smtp/email_service.go
+++ b/smtp/email_service.go
@@ -1,0 +1,104 @@
+package smtp
+
+import (
+	"context"
+	"errors"
+	"log"
+	"log/slog"
+	"strings"
+
+	"github.com/a-h/templ"
+	"github.com/prior-it/apollo/config"
+	"github.com/prior-it/apollo/core"
+	"gopkg.in/gomail.v2"
+)
+
+type EmailService struct {
+	from          string
+	d             *gomail.Dialer
+	notifications *core.EmailAddress
+}
+
+func NewEmailService(cfg config.EmailConfig) (*EmailService, error) {
+	d := gomail.NewDialer(
+		cfg.Host,
+		cfg.Port,
+		cfg.User,
+		cfg.Password,
+	)
+
+	s := EmailService{
+		from: cfg.From,
+		d:    d,
+	}
+
+	address, err := core.NewEmailAddress(cfg.Notifications)
+	switch {
+	case errors.Is(err, core.ErrEmailAddressEmpty):
+		slog.Info("Notification e-mail address empty, notifications will not be sent")
+	case err != nil:
+		return nil, err
+	default:
+		s.notifications = &address
+	}
+
+	return &s, nil
+}
+
+// SendEmail will build and send a basic e-mail message containing both a HTML template version (optional) as well as a plaintext alternative (required).
+// This will open a new server connection and immediately close it after sending the e-mail.
+func (s *EmailService) SendEmail(
+	ctx context.Context,
+	address core.EmailAddress,
+	subject string,
+	template *templ.Component,
+	plaintextMessage string,
+) error {
+	m := gomail.NewMessage()
+
+	m.SetHeader("From", s.from)
+	m.SetHeader("To", address.String())
+	m.SetHeader("Subject", subject)
+	m.SetBody("text/plain", plaintextMessage)
+
+	if template != nil {
+		var builder strings.Builder
+		err := (*template).Render(ctx, &builder)
+		if err != nil {
+			log.Fatal(err)
+		}
+		m.AddAlternative("text/html", builder.String())
+	}
+
+	return s.d.DialAndSend(m)
+}
+
+// SendNotification will send a specific plain-text notification to the configured notification
+// address.
+func (s *EmailService) SendNotification(
+	ctx context.Context,
+	subject string,
+	message string,
+) error {
+	if s.notifications == nil {
+		return core.ErrEmailAddressEmpty
+	}
+	return s.SendEmail(
+		ctx,
+		*s.notifications,
+		subject,
+		nil,
+		message,
+	)
+}
+
+// SendRawMessage will send a raw gomail message using the existing smtp connection.
+// Note that this overrides the "From" header to use the configured value.
+// This will open a new server connection and immediately close it after sending the e-mail.
+func (s *EmailService) SendRawMessage(
+	_ context.Context,
+	message *gomail.Message,
+) error {
+	message.SetHeader("From", s.from)
+	return s.d.DialAndSend(message)
+}


### PR DESCRIPTION
## This PR will:
- Add a "core.EmailService" interface
- Add a "smtp.EmailService" implementation that uses SMTP to send e-mails
- Add an EmailConfig section to config.Config

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
