### PR TITLE
Add option for applications to disable the i18n system

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,7 @@ type AppConfig struct {
 	AuthenticationKey      string `                     mapstructure:"AUTHKEY"`
 	EncryptionKey          string `                     mapstructure:"ENCKEY"`
 	DefaultPermissionGroup int    `                     mapstructure:"DEFAULTPERMGROUP"`
+	DisableI18n            bool
 	FallbackLang           string `default:"nl"`
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -196,8 +196,12 @@ func (server *Server[state]) AttachDefaultMiddleware() {
 		server.ContextMiddleware,
 		server.FeatureFlagMiddleware,
 		server.MiddlewareHandler(InjectApollo),
-		server.MiddlewareHandler(DetectLanguage),
 	)
+	if !server.cfg.App.DisableI18n {
+		server.UseStd(
+			server.MiddlewareHandler(DetectLanguage),
+		)
+	}
 }
 
 // Start a new goroutine that runs the server.


### PR DESCRIPTION
## This PR will:
- Add a configuration option to disable i18n, which fixes a possible nil pointer error when you don't set it up

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [x] I tested both up- and down-migrations
- [x] I ran `go mod tidy` after changing dependencies
- [x] I changed the PR title to be more descriptive
- [x] I added the shortcut autolink in the PR title (e.g. `[sc-000]`)
- [x] I used `git rebase -i` to clean up the commit history in this branch
