### PR TITLE
feature/add reply-to option in mailservice

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -107,6 +107,8 @@ type EmailConfig struct {
 	From     string
 	// Email address to send notifications to
 	Notifications string
+	// Optional email to send replies to
+	ReplyTo *string
 }
 
 type DatabaseConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -107,8 +107,6 @@ type EmailConfig struct {
 	From     string
 	// Email address to send notifications to
 	Notifications string
-	// Optional email to send replies to
-	ReplyTo *string
 }
 
 type DatabaseConfig struct {

--- a/smtp/email_service.go
+++ b/smtp/email_service.go
@@ -16,6 +16,7 @@ import (
 
 type EmailService struct {
 	from          string
+	replyTo       *core.EmailAddress
 	d             *gomail.Dialer
 	notifications *core.EmailAddress
 }
@@ -43,6 +44,18 @@ func NewEmailService(cfg config.EmailConfig) (*EmailService, error) {
 		s.notifications = address
 	}
 
+	if cfg.ReplyTo != nil {
+		rAddress, err := core.ParseEmailAddress(*cfg.ReplyTo)
+		switch {
+		case errors.Is(err, core.ErrEmailAddressEmpty):
+			slog.Info("ReplyTo e-mail address empty, notifications will not be sent")
+		case err != nil:
+			return nil, err
+		default:
+			s.replyTo = rAddress
+		}
+	}
+
 	return &s, nil
 }
 
@@ -60,6 +73,11 @@ func (s *EmailService) SendEmail(
 	m.SetHeader("From", s.from)
 	m.SetHeader("To", address.String())
 	m.SetHeader("Subject", subject)
+
+	if s.replyTo != nil {
+		m.SetHeader("Reply-To", s.replyTo.String())
+	}
+
 	m.SetBody("text/plain", plaintextMessage)
 
 	if template != nil {

--- a/smtp/email_service.go
+++ b/smtp/email_service.go
@@ -20,6 +20,11 @@ type EmailService struct {
 	notifications *core.EmailAddress
 }
 
+type EmailHeader struct {
+	key   string
+	value string
+}
+
 func NewEmailService(cfg config.EmailConfig) (*EmailService, error) {
 	d := gomail.NewDialer(
 		cfg.Host,
@@ -55,10 +60,7 @@ func (s *EmailService) SendEmail(
 	template *templ.Component,
 	plaintextMessage string,
 ) error {
-	return s.SendEmailWithExtraHeaders(ctx, address, subject, template, plaintextMessage, []struct {
-		key   string
-		value string
-	}{})
+	return s.SendEmailWithExtraHeaders(ctx, address, subject, template, plaintextMessage, []EmailHeader{})
 }
 
 func (s *EmailService) SendEmailWithExtraHeaders(
@@ -67,10 +69,7 @@ func (s *EmailService) SendEmailWithExtraHeaders(
 	subject string,
 	template *templ.Component,
 	plaintextMessage string,
-	extraHeaders []struct {
-		key   string
-		value string
-	},
+	extraHeaders []EmailHeader,
 ) error {
 	m := gomail.NewMessage()
 

--- a/smtp/email_service.go
+++ b/smtp/email_service.go
@@ -16,7 +16,6 @@ import (
 
 type EmailService struct {
 	from          string
-	replyTo       *core.EmailAddress
 	d             *gomail.Dialer
 	notifications *core.EmailAddress
 }
@@ -44,18 +43,6 @@ func NewEmailService(cfg config.EmailConfig) (*EmailService, error) {
 		s.notifications = address
 	}
 
-	if cfg.ReplyTo != nil {
-		rAddress, err := core.ParseEmailAddress(*cfg.ReplyTo)
-		switch {
-		case errors.Is(err, core.ErrEmailAddressEmpty):
-			slog.Info("ReplyTo e-mail address empty, notifications will not be sent")
-		case err != nil:
-			return nil, err
-		default:
-			s.replyTo = rAddress
-		}
-	}
-
 	return &s, nil
 }
 
@@ -68,14 +55,31 @@ func (s *EmailService) SendEmail(
 	template *templ.Component,
 	plaintextMessage string,
 ) error {
+	return s.SendEmailWithExtraHeaders(ctx, address, subject, template, plaintextMessage, []struct {
+		key   string
+		value string
+	}{})
+}
+
+func (s *EmailService) SendEmailWithExtraHeaders(
+	ctx context.Context,
+	address core.EmailAddress,
+	subject string,
+	template *templ.Component,
+	plaintextMessage string,
+	extraHeaders []struct {
+		key   string
+		value string
+	},
+) error {
 	m := gomail.NewMessage()
 
 	m.SetHeader("From", s.from)
 	m.SetHeader("To", address.String())
 	m.SetHeader("Subject", subject)
 
-	if s.replyTo != nil {
-		m.SetHeader("Reply-To", s.replyTo.String())
+	for _, header := range extraHeaders {
+		m.SetHeader(header.key, header.value)
 	}
 
 	m.SetBody("text/plain", plaintextMessage)

--- a/smtp/email_service.go
+++ b/smtp/email_service.go
@@ -21,8 +21,8 @@ type EmailService struct {
 }
 
 type EmailHeader struct {
-	key   string
-	value string
+	Key   string
+	Value string
 }
 
 func NewEmailService(cfg config.EmailConfig) (*EmailService, error) {
@@ -78,7 +78,7 @@ func (s *EmailService) SendEmailWithExtraHeaders(
 	m.SetHeader("Subject", subject)
 
 	for _, header := range extraHeaders {
-		m.SetHeader(header.key, header.value)
+		m.SetHeader(header.Key, header.Value)
 	}
 
 	m.SetBody("text/plain", plaintextMessage)


### PR DESCRIPTION
## This PR will:
- add a reply-to option for the emailservice

## Checklist:
- [x] I ran (and extended) the test suite
- [x] I ran `just lint`
- [ ] I tested both up- and down-migrations NA
- [ ] I ran `go mod tidy` after changing dependencies NA
- [x] I changed the PR title to be more descriptive
- [ ] I added the shortcut autolink in the PR title (e.g. `[sc-000]`) NA
- [x] I used `git rebase -i` to clean up the commit history in this branch
